### PR TITLE
chore(website): add cache-control headers

### DIFF
--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,3 +1,4 @@
+# ── Security headers (all responses) ──
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
@@ -6,5 +7,34 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'
 
+# ── Cache: HTML pages ──
+# Always revalidate; Cloudflare Pages purges edge cache on deploy so visitors get fresh content immediately.
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+# ── Cache: Astro hashed assets ──
+# Filenames contain a content hash — safe to cache forever.
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
+
+# ── Cache: static assets (images, favicons, fonts) ──
+# Not content-hashed, so use a moderate cache with revalidation.
+/images/*
+  Cache-Control: public, max-age=86400, must-revalidate
+
+/favicon*
+  Cache-Control: public, max-age=86400, must-revalidate
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+# ── Cache: OG / social images ──
+/og/*
+  Cache-Control: public, max-age=3600, must-revalidate
+
+# ── Cache: robots & sitemap ──
+/robots.txt
+  Cache-Control: public, max-age=86400
+
+/sitemap*.xml
+  Cache-Control: public, max-age=3600


### PR DESCRIPTION
## Summary

- Add granular cache-control headers for Cloudflare Pages
- HTML pages: always revalidate (`max-age=0, must-revalidate`)
- Astro hashed assets: cache forever (`immutable`)
- Static images/favicons: 24h cache with revalidation
- OG/social images: 1h cache
- Fonts (woff2): cache forever
- robots.txt/sitemap: short cache

## Test plan

- [ ] Deploy to preview and verify headers with `curl -I`

🤖 Generated with [Claude Code](https://claude.com/claude-code)