### PR TITLE
fix: serve a real social preview image for openwaggle.ai

### DIFF
--- a/website/src/components/SEO.astro
+++ b/website/src/components/SEO.astro
@@ -6,7 +6,7 @@ interface Props {
   noIndex?: boolean;
 }
 
-const { title, description, ogImage = '/og-image.png', noIndex = false } = Astro.props;
+const { title, description, ogImage = '/screenshots/hero-screenshot.png', noIndex = false } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = new URL(ogImage, Astro.site);
 ---

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ interface Props {
 const {
   title = 'OpenWaggle — The coding harness that lets your agents waggle.',
   description = 'Open source desktop coding agent with multi-model waggle mode. Two AI agents collaborate in structured turns until they converge on solutions.',
-  ogImage = '/og-image.png',
+  ogImage = '/screenshots/hero-screenshot.png',
   noIndex = false,
 } = Astro.props;
 ---


### PR DESCRIPTION
## Summary
- point the website social preview metadata at the existing hero screenshot
- stop referencing `/og-image.png`, which is not deployed and currently resolves to HTML
- restore proper X/Open Graph cards for `openwaggle.ai`

## Validation
- `pnpm --dir website build`
- verified generated metadata points at `https://openwaggle.ai/screenshots/hero-screenshot.png`