### PR TITLE
feat(tools): allow unrestricted file access with absolute paths

### DIFF
--- a/docs/user-guide/developer-guide.md
+++ b/docs/user-guide/developer-guide.md
@@ -185,7 +185,7 @@ Tools are defined in `src/main/tools/tools/` using `defineOpenWaggleTool()`:
 
 - Each tool has an Effect Schema input contract for argument validation.
 - `ToolContext` (project path, abort signal, dynamic skills) is bound explicitly per run.
-- Path resolution prevents escaping the project root.
+- Path resolution supports both relative (project-rooted) and absolute paths.
 - Results are structured as `{ kind: 'text' | 'json' }`.
 
 ### Feature System

--- a/src/main/agent/system-prompt.ts
+++ b/src/main/agent/system-prompt.ts
@@ -52,7 +52,7 @@ export const projectContextPromptFragment: AgentPromptFragment = {
   order: ORDER_VALUE_30,
   build: (context) => {
     if (context.hasProject) {
-      return `The user's project is located at: ${context.projectPath}\nAll file paths in tool calls should be relative to this project root.`
+      return `The user's project is located at: ${context.projectPath}\nFile paths in tool calls can be relative to this project root, or absolute paths to access files anywhere on the machine.`
     }
 
     return 'No project folder is currently selected. Ask the user to select a project folder if they want you to work with files.'

--- a/src/main/orchestration/__tests__/project-context.unit.test.ts
+++ b/src/main/orchestration/__tests__/project-context.unit.test.ts
@@ -282,18 +282,19 @@ describe('createExecutorTools', () => {
     expect(result).toEqual({ kind: 'text', text: 'hello world' })
   })
 
-  it('readFile tool rejects paths outside project', async () => {
+  it('readFile tool allows paths outside project', async () => {
     const tools = await createExecutorTools(tmpDir)
     const readFileTool = tools[0]
 
+    // Paths outside the project should not be rejected — they attempt a real read
     const result = await (readFileTool as { execute: (args: unknown) => Promise<unknown> }).execute(
       {
-        path: '../../../../etc/passwd',
+        path: '../../../../etc/nonexistent-file-for-test',
       },
     )
     expect(result).toEqual({
       kind: 'text',
-      text: 'Error: path is outside the project directory',
+      text: expect.stringContaining('Error reading file:'),
     })
   })
 

--- a/src/main/orchestration/project-context.ts
+++ b/src/main/orchestration/project-context.ts
@@ -374,12 +374,20 @@ export async function createExecutorTools(
 
   const ignore = await buildIgnorePatterns(projectPath)
   const readFileArgsSchema = Schema.Struct({
-    path: Schema.String.annotations({ description: 'File path relative to the project root' }),
+    path: Schema.String.annotations({
+      description: 'File path relative to the project root, or an absolute path',
+    }),
   })
   const globArgsSchema = Schema.Struct({
     pattern: Schema.String.annotations({
       description: 'Glob pattern (e.g., "**/*.ts", "src/**/*.tsx")',
     }),
+    path: Schema.optional(
+      Schema.String.annotations({
+        description:
+          'Base directory to search in. Defaults to the project root. Use an absolute path to search outside the project.',
+      }),
+    ),
   })
   const webFetchArgsSchema = Schema.Struct({
     url: Schema.String.annotations({
@@ -395,28 +403,28 @@ export async function createExecutorTools(
   const readFile = toolDefinition({
     name: 'readFile',
     description:
-      'Read a file from the project. Use this to gather additional context about the codebase when the provided project context is insufficient.',
+      'Read a file. Use this to gather additional context about the codebase when the provided project context is insufficient.',
     inputSchema: readFileArgsSchema,
   }).server(async (rawArgs: unknown) => {
     const args = decodeUnknownOrThrow(readFileArgsSchema, rawArgs)
     const resolved = path.resolve(projectPath, args.path)
-    if (!isPathInside(projectPath, resolved)) {
-      return textToolResult('Error: path is outside the project directory')
-    }
 
-    // Block reads of files excluded by .gitignore (secrets, build artifacts, deps)
-    const relPath = path.relative(projectPath, resolved)
-    const [allowed] = await fg(relPath, {
-      cwd: projectPath,
-      ignore,
-      onlyFiles: true,
-    })
-    if (!allowed) {
-      try {
-        await fs.stat(resolved)
-        return textToolResult('Error: file is excluded by project ignore patterns (.gitignore)')
-      } catch {
-        return textToolResult('Error reading file: file not found')
+    // Block reads of files excluded by .gitignore when inside the project
+    const isInsideProject = isPathInside(projectPath, resolved)
+    if (isInsideProject) {
+      const relPath = path.relative(projectPath, resolved)
+      const [allowed] = await fg(relPath, {
+        cwd: projectPath,
+        ignore,
+        onlyFiles: true,
+      })
+      if (!allowed) {
+        try {
+          await fs.stat(resolved)
+          return textToolResult('Error: file is excluded by project ignore patterns (.gitignore)')
+        } catch {
+          return textToolResult('Error reading file: file not found')
+        }
       }
     }
 
@@ -447,19 +455,16 @@ export async function createExecutorTools(
   const glob = toolDefinition({
     name: 'glob',
     description:
-      'Find files matching a glob pattern in the project. Use this to discover project structure and locate relevant files.',
+      'Find files matching a glob pattern. Use this to discover project structure and locate relevant files.',
     inputSchema: globArgsSchema,
   }).server(async (rawArgs: unknown) => {
     const args = decodeUnknownOrThrow(globArgsSchema, rawArgs)
-    const normalized = args.pattern.replaceAll('\\', '/')
-    if (path.isAbsolute(args.pattern) || normalized.split('/').includes('..')) {
-      return textToolResult('Error: pattern must be relative to the project root')
-    }
+    const cwd = args.path ?? projectPath
 
     try {
       const files = await fg(args.pattern, {
-        cwd: projectPath,
-        ignore,
+        cwd,
+        ignore: cwd === projectPath ? ignore : ['node_modules/**', '.git/**', 'dist/**', 'out/**'],
         onlyFiles: true,
         dot: false,
       })

--- a/src/main/tools/__tests__/define-tool.unit.test.ts
+++ b/src/main/tools/__tests__/define-tool.unit.test.ts
@@ -1,60 +1,34 @@
-import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { Schema } from '@shared/schema'
 import { ConversationId } from '@shared/types/brand'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   bindToolContextToTool,
   defineOpenWaggleTool,
   type NormalizedToolResult,
-  resolveProjectPath,
+  resolvePath,
 } from '../define-tool'
 import { withoutApproval } from '../without-approval'
 
-const tempDirs: string[] = []
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
-  tempDirs.push(dir)
-  return dir
-}
-
-describe('resolveProjectPath', () => {
-  afterEach(() => {
-    for (const dir of tempDirs.splice(0)) {
-      fs.rmSync(dir, { recursive: true, force: true })
-    }
-  })
-
-  it('resolves paths inside the project root', () => {
-    const projectRoot = makeTempDir('openwaggle-tool-project-')
-    const resolved = resolveProjectPath(projectRoot, 'src/main/index.ts')
+describe('resolvePath', () => {
+  it('resolves relative paths against the project root', () => {
+    const projectRoot = '/tmp/test-project'
+    const resolved = resolvePath(projectRoot, 'src/main/index.ts')
     expect(resolved).toBe(path.resolve(projectRoot, 'src/main/index.ts'))
   })
 
-  it('rejects traversal outside the project root', () => {
-    const projectRoot = makeTempDir('openwaggle-tool-project-')
-    expect(() => resolveProjectPath(projectRoot, '../../outside.txt')).toThrow(
-      /outside the project directory/i,
-    )
+  it('returns absolute paths as-is', () => {
+    const projectRoot = '/tmp/test-project'
+    const absolutePath = path.join(os.homedir(), 'other-repo/file.ts')
+    const resolved = resolvePath(projectRoot, absolutePath)
+    expect(resolved).toBe(absolutePath)
   })
 
-  it('rejects symlink escapes when target exists', () => {
-    const workspace = makeTempDir('openwaggle-tool-workspace-')
-    const projectRoot = path.join(workspace, 'project')
-    const outside = path.join(workspace, 'outside')
-    const insideLink = path.join(projectRoot, 'linked')
-    const outsideFile = path.join(outside, 'secret.txt')
-
-    fs.mkdirSync(projectRoot, { recursive: true })
-    fs.mkdirSync(outside, { recursive: true })
-    fs.writeFileSync(outsideFile, 'classified', 'utf-8')
-    fs.symlinkSync(outside, insideLink, 'dir')
-
-    expect(() => resolveProjectPath(projectRoot, 'linked/secret.txt')).toThrow(
-      /outside the project directory/i,
-    )
+  it('resolves parent traversal relative to project root', () => {
+    const projectRoot = '/tmp/test-project'
+    const resolved = resolvePath(projectRoot, '../../outside.txt')
+    expect(resolved).toBe(path.resolve(projectRoot, '../../outside.txt'))
   })
 })
 

--- a/src/main/tools/__tests__/define-tool.unit.test.ts
+++ b/src/main/tools/__tests__/define-tool.unit.test.ts
@@ -30,6 +30,13 @@ describe('resolvePath', () => {
     const resolved = resolvePath(projectRoot, '../../outside.txt')
     expect(resolved).toBe(path.resolve(projectRoot, '../../outside.txt'))
   })
+
+  it('resolves symlink paths lexically without following them', () => {
+    const projectRoot = '/tmp/test-project'
+    const resolved = resolvePath(projectRoot, 'linked/secret.txt')
+    // path.resolve is purely lexical — symlinks are not followed at resolution time
+    expect(resolved).toBe(path.join(projectRoot, 'linked/secret.txt'))
+  })
 })
 
 describe('NormalizedToolResult types', () => {

--- a/src/main/tools/define-tool.ts
+++ b/src/main/tools/define-tool.ts
@@ -1,10 +1,8 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import { BYTES_PER_KIBIBYTE, PERCENT_BASE } from '@shared/constants/constants'
 import { decodeUnknownOrThrow, type Schema, type SchemaType } from '@shared/schema'
 import type { ConversationId } from '@shared/types/brand'
 import type { AgentStreamChunk } from '@shared/types/stream'
-import { isPathInside } from '@shared/utils/paths'
 import { type ServerTool, type ToolExecutionContext, toolDefinition } from '@tanstack/ai'
 import { JSONSchema } from 'effect'
 import type { WaggleFileCache } from '../agent/waggle-file-cache'
@@ -15,7 +13,6 @@ import { applyContextInjection } from './context-injection-buffer'
 
 const logger = createLogger('tools')
 const MAX_TOOL_OUTPUT_BYTES = PERCENT_BASE * BYTES_PER_KIBIBYTE // 100 KB
-const projectRootCache = new Map<string, string>()
 
 /**
  * Convert an Effect Schema to a plain JSON Schema object that LLM providers accept.
@@ -300,38 +297,10 @@ function normalizeToolResult(result: string): NormalizedToolResult {
   }
 }
 
-/** Validate and resolve a file path within the project directory */
-export function resolveProjectPath(projectPath: string, filePath: string): string {
-  const resolved = path.resolve(projectPath, filePath)
-  const projectRoot = path.resolve(projectPath)
-  let projectRootReal = projectRootCache.get(projectPath)
-  if (projectRootReal === undefined) {
-    projectRootReal = fs.existsSync(projectRoot) ? fs.realpathSync(projectRoot) : projectRoot
-    projectRootCache.set(projectPath, projectRootReal)
-  }
-
-  // For existing files, resolve symlinks before checking
-  if (fs.existsSync(resolved)) {
-    const real = fs.realpathSync(resolved)
-    if (!isPathInside(projectRootReal, real)) {
-      throw new Error(`Path "${filePath}" resolves outside the project directory (symlink)`)
-    }
-    return resolved
-  }
-
-  // For new files (write operations), validate the parent directory
-  const parentDir = path.dirname(resolved)
-  if (fs.existsSync(parentDir)) {
-    const realParent = fs.realpathSync(parentDir)
-    if (!isPathInside(projectRootReal, realParent)) {
-      throw new Error(`Path "${filePath}" resolves outside the project directory (symlink)`)
-    }
-    return resolved
-  }
-
-  if (!isPathInside(projectRoot, resolved)) {
-    throw new Error(`Path "${filePath}" is outside the project directory`)
-  }
-
-  return resolved
+/**
+ * Resolve a file path for tool operations.
+ * Absolute paths are returned as-is. Relative paths are resolved against the project root.
+ */
+export function resolvePath(projectPath: string, filePath: string): string {
+  return path.resolve(projectPath, filePath)
 }

--- a/src/main/tools/tools/__tests__/glob.unit.test.ts
+++ b/src/main/tools/tools/__tests__/glob.unit.test.ts
@@ -37,7 +37,7 @@ function extractText(result: unknown): string {
 }
 
 async function executeGlob(
-  args: { pattern: string; ignore?: string[] },
+  args: { pattern: string; path?: string; ignore?: string[] },
   ctx: ToolContext,
 ): Promise<string> {
   const result = await executeToolWithContext(globTool, ctx, args)
@@ -69,18 +69,24 @@ describe('globTool', () => {
     expect(result).toBe('No files found matching the pattern.')
   })
 
-  it('rejects absolute paths', async () => {
+  it('allows absolute path as base directory', async () => {
     const dir = makeTempDir()
-    await expect(executeGlob({ pattern: '/etc/passwd' }, makeContext(dir))).rejects.toThrow(
-      'relative to the project root',
-    )
+    const otherDir = makeTempDir()
+    await fsp.writeFile(path.join(otherDir, 'external.ts'), 'x')
+
+    const result = await executeGlob({ pattern: '*.ts', path: otherDir }, makeContext(dir))
+    expect(result).toContain('external.ts')
   })
 
-  it('rejects parent directory traversal', async () => {
-    const dir = makeTempDir()
-    await expect(executeGlob({ pattern: '../../**/*.ts' }, makeContext(dir))).rejects.toThrow(
-      'cannot traverse outside',
-    )
+  it('allows parent directory traversal in patterns', async () => {
+    const workspace = makeTempDir()
+    const nested = path.join(workspace, 'a', 'b')
+    await fsp.mkdir(nested, { recursive: true })
+    await fsp.writeFile(path.join(workspace, 'root.ts'), 'x')
+
+    // Pattern traverses up from nested dir to workspace — should find root.ts
+    const result = await executeGlob({ pattern: '../../*.ts' }, makeContext(nested))
+    expect(result).toContain('root.ts')
   })
 
   it('respects custom ignore patterns', async () => {

--- a/src/main/tools/tools/edit-file.ts
+++ b/src/main/tools/tools/edit-file.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import { PERCENT_BASE } from '@shared/constants/constants'
 import { Schema } from '@shared/schema'
-import { defineOpenWaggleTool, resolveProjectPath } from '../define-tool'
+import { defineOpenWaggleTool, resolvePath } from '../define-tool'
 import { buildFileMutationResult } from './file-mutation-result'
 
 const SLICE_ARG_2 = 100
@@ -12,14 +12,16 @@ export const editFileTool = defineOpenWaggleTool({
     'Edit a file by replacing an exact string match with new content. The oldString must appear exactly once in the file. Read the file first to get the exact content to match.',
   needsApproval: true,
   inputSchema: Schema.Struct({
-    path: Schema.String.annotations({ description: 'File path relative to the project root' }),
+    path: Schema.String.annotations({
+      description: 'File path relative to the project root, or an absolute path',
+    }),
     oldString: Schema.String.annotations({
       description: 'The exact string to find and replace (must be unique in the file)',
     }),
     newString: Schema.String.annotations({ description: 'The replacement string' }),
   }),
   async execute(args, context) {
-    const filePath = resolveProjectPath(context.projectPath, args.path)
+    const filePath = resolvePath(context.projectPath, args.path)
     const content = await fs.readFile(filePath, 'utf-8')
 
     const occurrences = content.split(args.oldString).length - 1

--- a/src/main/tools/tools/glob.ts
+++ b/src/main/tools/tools/glob.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { Schema } from '@shared/schema'
 import fg from 'fast-glob'
 import { defineOpenWaggleTool } from '../define-tool'
@@ -9,11 +8,19 @@ const SLICE_ARG_2 = 200
 export const globTool = defineOpenWaggleTool({
   name: 'glob',
   description:
-    'Find files matching a glob pattern within the project directory. Returns matching file paths. Useful for discovering project structure and finding files.',
+    'Find files matching a glob pattern. Returns matching file paths. Useful for discovering project structure and finding files.',
   inputSchema: Schema.Struct({
     pattern: Schema.String.annotations({
       description: 'Glob pattern (e.g., "**/*.ts", "src/**/*.tsx", "*.json")',
     }),
+    path: Schema.optional(
+      Schema.NullOr(
+        Schema.String.annotations({
+          description:
+            'Base directory to search in. Defaults to the project root. Use an absolute path to search outside the project.',
+        }),
+      ),
+    ),
     ignore: Schema.optional(
       Schema.NullOr(
         Schema.Array(Schema.String).annotations({
@@ -23,10 +30,10 @@ export const globTool = defineOpenWaggleTool({
     ),
   }),
   async execute(args, context) {
-    assertPatternInsideProject(args.pattern)
+    const cwd = args.path ?? context.projectPath
 
     const files = await fg(args.pattern, {
-      cwd: context.projectPath,
+      cwd,
       ignore: [...(args.ignore ?? ['node_modules/**', '.git/**', 'dist/**', 'out/**'])],
       dot: false,
       onlyFiles: true,
@@ -43,15 +50,3 @@ export const globTool = defineOpenWaggleTool({
     return sorted.join('\n')
   },
 })
-
-function assertPatternInsideProject(pattern: string): void {
-  const normalized = pattern.replaceAll('\\', '/')
-  if (path.isAbsolute(pattern) || /^[A-Za-z]:\//.test(normalized)) {
-    throw new Error('Glob pattern must be relative to the project root')
-  }
-
-  const segments = normalized.split('/').filter(Boolean)
-  if (segments.includes('..')) {
-    throw new Error('Glob pattern cannot traverse outside the project root')
-  }
-}

--- a/src/main/tools/tools/list-files.ts
+++ b/src/main/tools/tools/list-files.ts
@@ -2,17 +2,18 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { BYTES_PER_KIBIBYTE, TRIPLE_FACTOR } from '@shared/constants/constants'
 import { Schema } from '@shared/schema'
-import { defineOpenWaggleTool, resolveProjectPath } from '../define-tool'
+import { defineOpenWaggleTool, resolvePath } from '../define-tool'
 
 export const listFilesTool = defineOpenWaggleTool({
   name: 'listFiles',
   description:
-    'List files and directories in a given path relative to the project root. Shows file types and sizes. Useful for exploring project structure.',
+    'List files and directories in a given path. Shows file types and sizes. Useful for exploring project structure and files outside the project.',
   inputSchema: Schema.Struct({
     path: Schema.optional(
       Schema.NullOr(
         Schema.String.annotations({
-          description: 'Directory path relative to the project root. Defaults to the project root.',
+          description:
+            'Directory path relative to the project root, or an absolute path. Defaults to the project root.',
         }),
       ),
     ),
@@ -25,7 +26,7 @@ export const listFilesTool = defineOpenWaggleTool({
     ),
   }),
   async execute(args, context) {
-    const dirPath = resolveProjectPath(context.projectPath, args.path ?? '.')
+    const dirPath = resolvePath(context.projectPath, args.path ?? '.')
 
     async function listDir(dir: string, depth: number): Promise<string[]> {
       const entries = await fs.readdir(dir, { withFileTypes: true })

--- a/src/main/tools/tools/read-file.ts
+++ b/src/main/tools/tools/read-file.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import { BYTES_PER_KIBIBYTE } from '@shared/constants/constants'
 import { Schema } from '@shared/schema'
-import { defineOpenWaggleTool, resolveProjectPath } from '../define-tool'
+import { defineOpenWaggleTool, resolvePath } from '../define-tool'
 
 const MAX_FILE_SIZE = BYTES_PER_KIBIBYTE * BYTES_PER_KIBIBYTE // 1 MB
 
@@ -22,9 +22,11 @@ function formatReadContent(content: string, maxLines?: number | null): string {
 export const readFileTool = defineOpenWaggleTool({
   name: 'readFile',
   description:
-    'Read the contents of a file at the given path relative to the project root. Returns the file content as text. Use this to understand existing code before making changes.',
+    'Read the contents of a file at the given path. Returns the file content as text. Use this to understand existing code before making changes.',
   inputSchema: Schema.Struct({
-    path: Schema.String.annotations({ description: 'File path relative to the project root' }),
+    path: Schema.String.annotations({
+      description: 'File path relative to the project root, or an absolute path',
+    }),
     maxLines: Schema.optional(
       Schema.NullOr(
         Schema.Number.annotations({
@@ -34,7 +36,7 @@ export const readFileTool = defineOpenWaggleTool({
     ),
   }),
   async execute(args, context) {
-    const filePath = resolveProjectPath(context.projectPath, args.path)
+    const filePath = resolvePath(context.projectPath, args.path)
 
     // During waggle runs, return cached content if another agent already read this file
     const cachedEntry = context.waggle?.fileCache.get(filePath)

--- a/src/main/tools/tools/write-file.ts
+++ b/src/main/tools/tools/write-file.ts
@@ -1,13 +1,15 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { Schema } from '@shared/schema'
-import { defineOpenWaggleTool, resolveProjectPath } from '../define-tool'
+import { defineOpenWaggleTool, resolvePath } from '../define-tool'
 import { buildFileMutationResult } from './file-mutation-result'
 
 const MAX_ATTACHMENT_LIST_PREVIEW = 5
 
 const writeFileArgsSchema = Schema.Struct({
-  path: Schema.String.annotations({ description: 'File path relative to the project root' }),
+  path: Schema.String.annotations({
+    description: 'File path relative to the project root, or an absolute path',
+  }),
   content: Schema.optional(
     Schema.NullOr(
       Schema.String.annotations({
@@ -60,11 +62,11 @@ function resolveContentFromAttachment(
 export const writeFileTool = defineOpenWaggleTool({
   name: 'writeFile',
   description:
-    'Write content to a file at the given path relative to the project root. Creates the file and any parent directories if they do not exist, and overwrites the file if it already exists. For large user attachments, prefer passing attachmentName (or only path when exactly one attachment is present) instead of embedding full text in content.',
+    'Write content to a file at the given path. Creates the file and any parent directories if they do not exist, and overwrites the file if it already exists. For large user attachments, prefer passing attachmentName (or only path when exactly one attachment is present) instead of embedding full text in content.',
   needsApproval: true,
   inputSchema: writeFileArgsSchema,
   async execute(args, context) {
-    const filePath = resolveProjectPath(context.projectPath, args.path)
+    const filePath = resolvePath(context.projectPath, args.path)
     await fs.mkdir(path.dirname(filePath), { recursive: true })
 
     let beforeContent = ''

--- a/website/src/content/docs/developer-guide/architecture.md
+++ b/website/src/content/docs/developer-guide/architecture.md
@@ -46,7 +46,7 @@ In Waggle Mode, two agents take alternating turns on the same task. The orchestr
 
 ## Tool System
 
-Tools are the agent's interface to your project. Each tool has a defined input contract, and tools that modify files or run commands require your approval before executing. Tools are sandboxed to your project directory — the agent cannot access files outside your project root.
+Tools are the agent's interface to your project. Each tool has a defined input contract, and tools that modify files or run commands require your approval before executing. Tools default to the project directory but can access files anywhere on the machine using absolute paths.
 
 ## Extensibility
 

--- a/website/src/content/docs/using-openwaggle/waggle-mode.md
+++ b/website/src/content/docs/using-openwaggle/waggle-mode.md
@@ -88,7 +88,7 @@ Even though tools run without asking, several safeguards remain active:
 
 - **Scoped to the session** — Auto-approval only applies during the active Waggle session. Once the session ends, normal approval rules resume immediately.
 - **Environment filtering** — Shell commands still receive a filtered environment. Your API keys and sensitive environment variables are never exposed to commands the agents run, even in auto-approval mode.
-- **Project sandboxing** — File operations are still restricted to your project directory. Agents cannot read or write files outside your project root.
+- **Project-rooted by default** — File operations default to your project directory, but agents can access files outside your project root using absolute paths when needed.
 - **Unforgeable token** — Internally, auto-approval is gated by a branded security token (a JavaScript `Symbol` that cannot be created or faked outside the orchestration layer). This prevents auto-approval from being accidentally activated by other parts of the application.
 - **Not persisted** — The auto-approval token only exists in memory during the session. It's never saved to disk or included in conversation history.
 

--- a/website/src/content/docs/using-openwaggle/waggle-mode.md
+++ b/website/src/content/docs/using-openwaggle/waggle-mode.md
@@ -88,7 +88,7 @@ Even though tools run without asking, several safeguards remain active:
 
 - **Scoped to the session** — Auto-approval only applies during the active Waggle session. Once the session ends, normal approval rules resume immediately.
 - **Environment filtering** — Shell commands still receive a filtered environment. Your API keys and sensitive environment variables are never exposed to commands the agents run, even in auto-approval mode.
-- **Project-rooted by default** — File operations default to your project directory, but agents can access files outside your project root using absolute paths when needed.
+- **Project-rooted by default** — File operations default to your project directory. Agents can use absolute paths to access files outside the project root, which means auto-approved writes may reach beyond your project. The session-scoped unforgeable token and environment filtering limit exposure, but be aware of this when running Waggle sessions.
 - **Unforgeable token** — Internally, auto-approval is gated by a branded security token (a JavaScript `Symbol` that cannot be created or faked outside the orchestration layer). This prevents auto-approval from being accidentally activated by other parts of the application.
 - **Not persisted** — The auto-approval token only exists in memory during the session. It's never saved to disk or included in conversation history.
 


### PR DESCRIPTION
## Summary

- Remove the project-root sandbox from all file tools (`readFile`, `writeFile`, `editFile`, `listFiles`, `glob`) so the agent can access files anywhere on the machine using absolute paths
- Relative paths still resolve against the project root as before (backwards compatible)
- Sub-agent executor tools get the same unrestricted access
- Gitignore filtering still applies for files inside the project; AGENTS.md/SKILL.md resolution remains project-scoped for security

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:unit` — all 2040 tests pass
- [ ] Manual: verify the agent can read a file outside the project root with an absolute path
- [ ] Manual: verify glob with absolute `path` parameter finds files in external directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)