### PR TITLE
fix(website): enable edge caching for HTML pages

### DIFF
--- a/website/public/_headers
+++ b/website/public/_headers
@@ -8,9 +8,9 @@
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'
 
 # ── Cache: HTML pages ──
-# Always revalidate; Cloudflare Pages purges edge cache on deploy so visitors get fresh content immediately.
+# Keep browsers revalidating HTML, but allow shared/CDN caches to retain a fresh copy briefly.
 /*.html
-  Cache-Control: public, max-age=0, must-revalidate
+  Cache-Control: public, max-age=0, s-maxage=3600, must-revalidate
 
 # ── Cache: Astro hashed assets ──
 # Filenames contain a content hash — safe to cache forever.


### PR DESCRIPTION
## Summary
- keep browser revalidation for HTML
- add `s-maxage=3600` so shared/CDN caches can retain HTML briefly
- leave hashed asset caching unchanged

## Why
Live checks showed:
- `/` -> `cf-cache-status: DYNAMIC`
- `/docs/...` -> `cf-cache-status: DYNAMIC`
- `/_astro/...` -> `cf-cache-status: HIT`

This change targets the missing shared-cache TTL on HTML responses while preserving `max-age=0` for browsers.