### PR TITLE
Fix macOS release installer verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,7 @@ jobs:
           test -f "$ARTIFACT_DIR/$ARM64_DMG"
           test -f "$ARTIFACT_DIR/$X64_DMG"
 
-          MOUNT_POINT="$(hdiutil attach -nobrowse -readonly "$ARTIFACT_DIR/$ARM64_DMG" | awk '/\/Volumes\// { print $NF; exit }')"
+          MOUNT_POINT="$(hdiutil attach -nobrowse -readonly "$ARTIFACT_DIR/$ARM64_DMG" | awk -F'\t' '/\/Volumes\// { print $NF; exit }')"
           trap 'hdiutil detach "$MOUNT_POINT" -quiet >/dev/null 2>&1 || true' EXIT
           APP_PATH=$(find "$MOUNT_POINT" -maxdepth 1 -name '*.app' | head -n 1)
           test -d "$APP_PATH"


### PR DESCRIPTION
## Summary

Fix the macOS release installer verification step when the mounted DMG volume name contains spaces.

## Root Cause

The release workflow mounted the arm64 DMG and parsed the mount path with whitespace-based `awk` field splitting:

```bash
awk '/\/Volumes\// { print $NF; exit }'
```

The generated volume path includes the versioned app name, for example `/Volumes/OpenWaggle 0.3.0-alpha.32-arm64`. Splitting on spaces returned only `0.3.0-alpha.32-arm64`, so the following `find "$MOUNT_POINT"` failed.

## Fix

Use tab-delimited `hdiutil attach` parsing, matching the safer pattern already used by `scripts/install.sh`, so paths with spaces are preserved.

## Validation

- Reproduced the log failure from run `26049046979`, job `76581795784`
- Shell parser smoke test preserved `/Volumes/OpenWaggle 0.3.0-alpha.32-arm64`
- `python3` YAML parse for `.github/workflows/release.yml`
- `git diff --check`
- `pnpm dlx fallow audit --base main`
