### PR TITLE
fix(chat): keep long pasted user messages within bubble

### DIFF
--- a/src/renderer/src/features/chat/components/UserMessageBubble.tsx
+++ b/src/renderer/src/features/chat/components/UserMessageBubble.tsx
@@ -138,7 +138,12 @@ export function UserMessageBubble({
 
   return (
     <div className="group/user-msg flex justify-end w-full">
-      <div className="relative rounded-[16px_16px_2px_16px] bg-bg-hover border border-border-light py-2.5 px-3.5">
+      <div
+        className={cn(
+          'relative min-w-0 max-w-full rounded-[16px_16px_2px_16px]',
+          'border border-border-light bg-bg-hover px-3.5 py-2.5',
+        )}
+      >
         {attachmentParts.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mb-2">
             {attachmentParts.map((p, i) => (
@@ -150,7 +155,7 @@ export function UserMessageBubble({
           </div>
         )}
         {contentParts.length > 0 && (
-          <div className="prose prose-user max-w-none">
+          <div className="prose prose-user max-w-none break-words [overflow-wrap:anywhere]">
             {contentParts.map((p, i) => (
               <ReactMarkdown
                 key={`${message.id}-text-${String(i)}`}

--- a/src/renderer/src/features/chat/components/__tests__/UserMessageBubble.component.test.tsx
+++ b/src/renderer/src/features/chat/components/__tests__/UserMessageBubble.component.test.tsx
@@ -151,6 +151,34 @@ describe('UserMessageBubble', () => {
     expect(proseDiv).toBeInTheDocument()
   })
 
+  it('keeps long pasted tokens inside the user bubble width constraints', () => {
+    const longToken = 'a'.repeat(800)
+    const message = createUserMessage('u1', [{ type: 'text', content: longToken }])
+    const { container } = render(<UserMessageBubble message={message} />)
+
+    const outerDiv = container.firstChild
+    expect(outerDiv).toBeInstanceOf(HTMLDivElement)
+    if (!(outerDiv instanceof HTMLDivElement)) {
+      throw new Error('Expected outer user message element')
+    }
+
+    const bubbleDiv = outerDiv.firstElementChild
+    expect(bubbleDiv).toBeInstanceOf(HTMLDivElement)
+    if (!(bubbleDiv instanceof HTMLDivElement)) {
+      throw new Error('Expected inner user bubble element')
+    }
+
+    expect(bubbleDiv.className).toContain('min-w-0')
+    expect(bubbleDiv.className).toContain('max-w-full')
+
+    const proseDiv = container.querySelector('.prose-user')
+    expect(proseDiv).toBeInTheDocument()
+    if (!(proseDiv instanceof HTMLDivElement)) {
+      throw new Error('Expected prose wrapper element')
+    }
+    expect(proseDiv.className).toContain('break-words')
+  })
+
   it('renders attachment text parts as chips instead of markdown', () => {
     const message = createUserMessage('u1', [
       { type: 'text', content: 'Check this file' },


### PR DESCRIPTION
## Summary
- add width constraints (`min-w-0 max-w-full`) to user message bubbles so they shrink within transcript rows
- add long-token wrapping (`break-words` + `overflow-wrap:anywhere`) for user markdown content
- add a regression component test for long unbroken pasted text

## Validation
- `pnpm test:component -- src/renderer/src/features/chat/components/__tests__/UserMessageBubble.component.test.tsx`
- `pnpm lint`
- `npx -y react-doctor@latest . --verbose --diff main`
