### PR TITLE
Fix packaged app child process PATH

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -34,7 +34,7 @@ Load `.agents/skills/pi-integration/SKILL.md` for details.
 Load `.agents/skills/electron-runtime/SKILL.md` for details.
 
 - Native addons have separate Node and Electron ABI targets. Rebuild with the repo scripts before blaming app code.
-- Packaged apps may not inherit a shell PATH. Pi package/resource loading that shells out to npm needs an adapter-controlled npm-compatible PATH.
+- Packaged apps may not inherit a shell PATH. Pi package/resource loading and Pi-run child processes that shell out to tools need an adapter-controlled npm-compatible PATH, including common user tool dirs such as `~/Library/pnpm` on macOS.
 - `electron-builder` with pnpm can omit transitive runtime modules unless explicit dependencies are present; `ms` is intentionally explicit for `electron-updater`.
 - On Apple silicon, performance/package QA should use arm64 outputs, not Rosetta x64 output from a universal build folder.
 - Electron Playwright E2E requires isolated user data and single-instance lock opt-out when another OpenWaggle instance is running.

--- a/src/main/__tests__/env.unit.test.ts
+++ b/src/main/__tests__/env.unit.test.ts
@@ -1,12 +1,7 @@
 import { homedir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-  getCurrentProcessPath,
-  getNpmCompatiblePath,
-  getSafeChildEnv,
-  initializeProcessPath,
-} from '../env'
+import { getNpmCompatiblePath, getSafeChildEnv } from '../env'
 
 const MINIMAL_PATH = ['/usr/bin', '/bin'].join(delimiter)
 
@@ -43,12 +38,13 @@ describe('main process environment helpers', () => {
     expect(entries).toContain('/usr/local/bin')
   })
 
-  it('initializes the main process PATH for packaged app child processes', () => {
-    vi.stubEnv('PATH', MINIMAL_PATH)
+  it('preserves existing PATH precedence before npm-compatible fallbacks', () => {
+    const existingEntries = ['/custom/shims', '/usr/bin', '/bin']
+    vi.stubEnv('PATH', existingEntries.join(delimiter))
 
-    initializeProcessPath()
+    const entries = pathEntries(getSafeChildEnv().PATH)
 
-    const entries = pathEntries(getCurrentProcessPath())
+    expect(entries.slice(0, existingEntries.length)).toEqual(existingEntries)
     expect(entries).toContain(join(homedir(), '.local', 'bin'))
     expect(entries).toContain('/usr/local/bin')
   })

--- a/src/main/__tests__/env.unit.test.ts
+++ b/src/main/__tests__/env.unit.test.ts
@@ -1,0 +1,55 @@
+import { homedir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getCurrentProcessPath,
+  getNpmCompatiblePath,
+  getSafeChildEnv,
+  initializeProcessPath,
+} from '../env'
+
+const MINIMAL_PATH = ['/usr/bin', '/bin'].join(delimiter)
+
+function pathEntries(value: string | undefined) {
+  return value?.split(delimiter) ?? []
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('main process environment helpers', () => {
+  it('adds common user tool directories to the npm-compatible PATH', () => {
+    vi.stubEnv('PATH', MINIMAL_PATH)
+
+    const entries = pathEntries(getNpmCompatiblePath())
+
+    expect(entries).toContain(join(homedir(), '.local', 'bin'))
+    expect(entries).toContain(join(homedir(), '.volta', 'bin'))
+    expect(entries).toContain('/usr/local/bin')
+    if (process.platform === 'darwin') {
+      expect(entries).toContain(join(homedir(), 'Library', 'pnpm'))
+      expect(entries).toContain('/opt/homebrew/bin')
+    }
+  })
+
+  it('uses the npm-compatible PATH for safe child process environments', () => {
+    vi.stubEnv('PATH', MINIMAL_PATH)
+
+    const childEnv = getSafeChildEnv()
+    const entries = pathEntries(childEnv.PATH)
+
+    expect(entries).toContain(join(homedir(), '.local', 'bin'))
+    expect(entries).toContain('/usr/local/bin')
+  })
+
+  it('initializes the main process PATH for packaged app child processes', () => {
+    vi.stubEnv('PATH', MINIMAL_PATH)
+
+    initializeProcessPath()
+
+    const entries = pathEntries(getCurrentProcessPath())
+    expect(entries).toContain(join(homedir(), '.local', 'bin'))
+    expect(entries).toContain('/usr/local/bin')
+  })
+})

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -94,15 +94,16 @@ export function getNpmCompatiblePath(): string {
     result.push(value)
   }
 
+  // Preserve user PATH precedence; extra directories are fallbacks for GUI-launched apps.
+  for (const value of (process.env.PATH ?? '').split(delimiter)) {
+    addPath(value)
+  }
+
   for (const value of getUserToolPathDirs()) {
     addPath(value)
   }
 
   for (const value of getNpmCompatiblePathDirs()) {
-    addPath(value)
-  }
-
-  for (const value of (process.env.PATH ?? '').split(delimiter)) {
     addPath(value)
   }
 
@@ -130,14 +131,6 @@ function getUserToolPathDirs() {
       ? [...MACOS_USER_TOOL_PATH_SEGMENTS, ...POSIX_USER_TOOL_PATH_SEGMENTS]
       : POSIX_USER_TOOL_PATH_SEGMENTS
   return pathSegments.map((segments) => join(homeDir, ...segments))
-}
-
-export function initializeProcessPath(): void {
-  process.env.PATH = getNpmCompatiblePath()
-}
-
-export function getCurrentProcessPath(): string | undefined {
-  return process.env.PATH
 }
 
 export async function withNpmCompatibleProcessEnv<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -1,4 +1,5 @@
-import { delimiter } from 'node:path'
+import { homedir } from 'node:os'
+import { delimiter, join } from 'node:path'
 import { decodeUnknownOrThrow, Schema, type SchemaType } from '@shared/schema'
 
 const optionalUrlSchema = Schema.optional(
@@ -37,6 +38,16 @@ const MACOS_NPM_COMPATIBLE_PATH_DIRS = [
   '/sbin',
 ]
 const POSIX_NPM_COMPATIBLE_PATH_DIRS = ['/usr/local/bin', '/usr/bin', '/bin']
+const POSIX_USER_TOOL_PATH_SEGMENTS = [
+  ['.local', 'bin'],
+  ['.volta', 'bin'],
+  ['.asdf', 'shims'],
+  ['.mise', 'shims'],
+  ['.cargo', 'bin'],
+  ['.bun', 'bin'],
+  ['.deno', 'bin'],
+] as const
+const MACOS_USER_TOOL_PATH_SEGMENTS = [['Library', 'pnpm']] as const
 
 let temporaryProcessEnvQueue: Promise<void> = Promise.resolve()
 
@@ -47,7 +58,7 @@ let temporaryProcessEnvQueue: Promise<void> = Promise.resolve()
  */
 export function getSafeChildEnv(): Record<string, string | undefined> {
   return {
-    PATH: process.env.PATH,
+    PATH: getNpmCompatiblePath(),
     HOME: process.env.HOME,
     SHELL: process.env.SHELL,
     TERM: process.env.TERM,
@@ -83,6 +94,10 @@ export function getNpmCompatiblePath(): string {
     result.push(value)
   }
 
+  for (const value of getUserToolPathDirs()) {
+    addPath(value)
+  }
+
   for (const value of getNpmCompatiblePathDirs()) {
     addPath(value)
   }
@@ -102,6 +117,27 @@ function getNpmCompatiblePathDirs() {
     return []
   }
   return POSIX_NPM_COMPATIBLE_PATH_DIRS
+}
+
+function getUserToolPathDirs() {
+  if (process.platform === 'win32') {
+    return []
+  }
+
+  const homeDir = homedir()
+  const pathSegments =
+    process.platform === 'darwin'
+      ? [...MACOS_USER_TOOL_PATH_SEGMENTS, ...POSIX_USER_TOOL_PATH_SEGMENTS]
+      : POSIX_USER_TOOL_PATH_SEGMENTS
+  return pathSegments.map((segments) => join(homeDir, ...segments))
+}
+
+export function initializeProcessPath(): void {
+  process.env.PATH = getNpmCompatiblePath()
+}
+
+export function getCurrentProcessPath(): string | undefined {
+  return process.env.PATH
 }
 
 export async function withNpmCompatibleProcessEnv<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { app, BrowserWindow, Menu, shell } from 'electron'
 import { reconcileInterruptedAgentRuns } from './application/agent-run-service'
-import { env } from './env'
+import { env, initializeProcessPath } from './env'
 import { persistAllActiveRuns } from './ipc/agent-handler'
 import { cleanupTerminals, registerAllIpcHandlers } from './ipc/handlers'
 import { createLogger, initFileLogger } from './logger'
@@ -279,6 +279,7 @@ function registerAppLifecycle() {
 }
 
 function startApp() {
+  initializeProcessPath()
   configureAppStoragePaths(app, env.OPENWAGGLE_USER_DATA_DIR)
 
   if (env.OPENWAGGLE_DISABLE_SINGLE_INSTANCE !== '1') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { app, BrowserWindow, Menu, shell } from 'electron'
 import { reconcileInterruptedAgentRuns } from './application/agent-run-service'
-import { env, initializeProcessPath } from './env'
+import { env } from './env'
 import { persistAllActiveRuns } from './ipc/agent-handler'
 import { cleanupTerminals, registerAllIpcHandlers } from './ipc/handlers'
 import { createLogger, initFileLogger } from './logger'
@@ -279,7 +279,6 @@ function registerAppLifecycle() {
 }
 
 function startApp() {
-  initializeProcessPath()
   configureAppStoragePaths(app, env.OPENWAGGLE_USER_DATA_DIR)
 
   if (env.OPENWAGGLE_DISABLE_SINGLE_INSTANCE !== '1') {


### PR DESCRIPTION
## Summary

- normalize the main-process PATH at startup so packaged OpenWaggle can find common user tools
- include macOS pnpm, Homebrew/Node, and common user tool directories in safe child process envs
- add regression coverage for minimal packaged-app PATH environments

## Validation

- `pnpm exec vitest run -c vitest.unit.config.ts src/main/__tests__/env.unit.test.ts`
- `pnpm typecheck:node`
- `pnpm exec biome check src/main/env.ts src/main/index.ts src/main/__tests__/env.unit.test.ts`
- `pnpm exec eslint src/main/env.ts src/main/index.ts src/main/__tests__/env.unit.test.ts --max-warnings=0`
- `pnpm check`
- `pnpm check:repository-standards`

## Notes

Validation was run with an explicit shell PATH because the currently running built app process had the broken packaged PATH before this fix.