### PR TITLE
[codex] Fix Pi compaction settlement

### DIFF
--- a/src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle-settlement.unit.test.ts
+++ b/src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle-settlement.unit.test.ts
@@ -1,0 +1,207 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent'
+import type { HydratedAgentSendPayload } from '@shared/types/agent'
+import { SessionId, SupportedModelId } from '@shared/types/brand'
+import type { SessionDetail } from '@shared/types/session'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentKernelRunInput } from '../../../../ports/agent-kernel-service'
+import { runSubscribedPiOperation } from '../run-lifecycle'
+
+const POST_RUN_SETTLE_MAX_MS = 15_000
+
+const lifecycleMocks = vi.hoisted(() => ({
+  disposeOpenWagglePiSession: vi.fn(async () => undefined),
+}))
+
+vi.mock('../../pi-session-lifecycle', () => ({
+  createOpenWaggleAgentSessionFromServices: vi.fn(),
+  disposeOpenWagglePiSession: lifecycleMocks.disposeOpenWagglePiSession,
+}))
+
+type PiAgentMessage = AgentSession['agent']['state']['messages'][number]
+
+interface FakeAgentState {
+  messages: PiAgentMessage[]
+}
+
+interface FakeSession {
+  readonly sessionId: string
+  readonly sessionFile: string
+  readonly agent: {
+    readonly state: FakeAgentState
+    readonly waitForIdle: () => Promise<void>
+    readonly hasQueuedMessages: () => boolean
+  }
+  readonly sessionManager: {
+    readonly getEntries: () => readonly unknown[]
+    readonly getLeafId: () => string | null
+  }
+  readonly abort: () => Promise<void>
+  readonly isCompacting: boolean
+  readonly isStreaming: boolean
+}
+
+function sessionDetail(): SessionDetail {
+  return {
+    id: SessionId('run-lifecycle-session'),
+    title: 'Run lifecycle',
+    projectPath: '/repo',
+    piSessionId: 'pi-session-run-lifecycle',
+    piSessionFile: '/repo/.pi/session.jsonl',
+    messages: [],
+    createdAt: 1,
+    updatedAt: 2,
+  }
+}
+
+function runInput(
+  payload: HydratedAgentSendPayload,
+  signal: AbortSignal = new AbortController().signal,
+): AgentKernelRunInput {
+  return {
+    session: sessionDetail(),
+    runId: 'run-lifecycle-test',
+    payload,
+    model: SupportedModelId('openai/gpt-5.5'),
+    signal,
+    onEvent: vi.fn(),
+  }
+}
+
+function assistantMessage(text: string): PiAgentMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    api: 'openai-responses',
+    provider: 'openai-codex',
+    model: 'openai/gpt-5.5',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: 'stop',
+    timestamp: Date.now(),
+  }
+}
+
+function payload(): HydratedAgentSendPayload {
+  return {
+    text: 'Continue',
+    thinkingLevel: 'high',
+    attachments: [],
+  }
+}
+
+describe('run lifecycle settlement edge cases', () => {
+  beforeEach(() => {
+    lifecycleMocks.disposeOpenWagglePiSession.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('bounds stalled Pi idle waits with the settlement timeout', async () => {
+    vi.useFakeTimers()
+
+    const state: FakeAgentState = { messages: [] }
+    const session: FakeSession = {
+      sessionId: 'pi-session-run-lifecycle',
+      sessionFile: '/repo/.pi/session.jsonl',
+      agent: {
+        state,
+        waitForIdle: vi.fn(() => new Promise<void>(() => undefined)),
+        hasQueuedMessages: vi.fn(() => false),
+      },
+      sessionManager: {
+        getEntries: vi.fn(() => []),
+        getLeafId: vi.fn(() => null),
+      },
+      abort: vi.fn(async () => undefined),
+      isCompacting: false,
+      isStreaming: false,
+    }
+
+    const resultPromise = runSubscribedPiOperation({
+      runInput: runInput(payload()),
+      session: fromPartial<AgentSession>(session),
+      unsubscribe: vi.fn(),
+      abortWarning: 'abort failed',
+      preAbortWarning: 'pre-abort failed',
+      operation: async () => {
+        state.messages.push(assistantMessage('Finished despite idle wait stall'))
+      },
+      buildErrorMessages: () => [],
+    })
+
+    await vi.advanceTimersByTimeAsync(POST_RUN_SETTLE_MAX_MS)
+    const result = await resultPromise
+
+    expect(session.agent.waitForIdle).toHaveBeenCalledOnce()
+    expect('terminalError' in result ? result.terminalError : undefined).toBeUndefined()
+    expect(result.newMessages).toHaveLength(2)
+  })
+
+  it('ignores aborts that arrive after the Pi operation completed', async () => {
+    const controller = new AbortController()
+    const state: FakeAgentState = { messages: [] }
+    let compacting = false
+    let abortDuringNextIdleWait = false
+
+    const session: FakeSession = {
+      sessionId: 'pi-session-run-lifecycle',
+      sessionFile: '/repo/.pi/session.jsonl',
+      agent: {
+        state,
+        waitForIdle: vi.fn(async () => {
+          if (abortDuringNextIdleWait) {
+            abortDuringNextIdleWait = false
+            compacting = false
+            controller.abort()
+          }
+        }),
+        hasQueuedMessages: vi.fn(() => false),
+      },
+      sessionManager: {
+        getEntries: vi.fn(() => []),
+        getLeafId: vi.fn(() => null),
+      },
+      abort: vi.fn(async () => undefined),
+      get isCompacting() {
+        return compacting
+      },
+      get isStreaming() {
+        return false
+      },
+    }
+
+    const result = await runSubscribedPiOperation({
+      runInput: runInput(payload(), controller.signal),
+      session: fromPartial<AgentSession>(session),
+      unsubscribe: vi.fn(),
+      abortWarning: 'abort failed',
+      preAbortWarning: 'pre-abort failed',
+      operation: async () => {
+        state.messages.push(assistantMessage('Finished before late abort'))
+        compacting = true
+        abortDuringNextIdleWait = true
+      },
+      buildErrorMessages: () => [],
+    })
+
+    expect(controller.signal.aborted).toBe(true)
+    expect(session.abort).not.toHaveBeenCalled()
+    expect('aborted' in result ? result.aborted : undefined).toBeUndefined()
+    expect(result.newMessages).toHaveLength(2)
+  })
+})

--- a/src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle.unit.test.ts
+++ b/src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle.unit.test.ts
@@ -1,0 +1,204 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent'
+import { getMessageText, type HydratedAgentSendPayload } from '@shared/types/agent'
+import { SessionId, SupportedModelId } from '@shared/types/brand'
+import type { SessionDetail } from '@shared/types/session'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentKernelRunInput } from '../../../../ports/agent-kernel-service'
+import { runSubscribedPiOperation } from '../run-lifecycle'
+
+const lifecycleMocks = vi.hoisted(() => ({
+  disposeOpenWagglePiSession: vi.fn(async () => undefined),
+}))
+
+vi.mock('../../pi-session-lifecycle', () => ({
+  createOpenWaggleAgentSessionFromServices: vi.fn(),
+  disposeOpenWagglePiSession: lifecycleMocks.disposeOpenWagglePiSession,
+}))
+
+interface FakeAgentState {
+  messages: unknown[]
+}
+
+interface FakeSession {
+  readonly sessionId: string
+  readonly sessionFile: string
+  readonly agent: {
+    readonly state: FakeAgentState
+    readonly waitForIdle: () => Promise<void>
+    readonly hasQueuedMessages: () => boolean
+  }
+  readonly sessionManager: {
+    readonly getEntries: () => readonly unknown[]
+    readonly getLeafId: () => string | null
+  }
+  readonly abort: () => Promise<void>
+  readonly isCompacting: boolean
+  readonly isStreaming: boolean
+}
+
+function sessionDetail(): SessionDetail {
+  return {
+    id: SessionId('run-lifecycle-session'),
+    title: 'Run lifecycle',
+    projectPath: '/repo',
+    piSessionId: 'pi-session-run-lifecycle',
+    piSessionFile: '/repo/.pi/session.jsonl',
+    messages: [],
+    createdAt: 1,
+    updatedAt: 2,
+  }
+}
+
+function runInput(payload: HydratedAgentSendPayload): AgentKernelRunInput {
+  return {
+    session: sessionDetail(),
+    runId: 'run-lifecycle-test',
+    payload,
+    model: SupportedModelId('openai/gpt-5.5'),
+    signal: new AbortController().signal,
+    onEvent: vi.fn(),
+  }
+}
+
+function assistantMessage(input: {
+  readonly text: string
+  readonly stopReason: 'stop' | 'error'
+  readonly errorMessage?: string
+}) {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text: input.text }],
+    model: 'openai/gpt-5.5',
+    stopReason: input.stopReason,
+    ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+  }
+}
+
+describe('run lifecycle settlement', () => {
+  beforeEach(() => {
+    lifecycleMocks.disposeOpenWagglePiSession.mockClear()
+  })
+
+  it('waits for delayed post-run recovery updates before snapshot capture', async () => {
+    const messages: unknown[] = []
+    let compacting = false
+    const state: FakeAgentState = { messages }
+
+    const session: FakeSession = {
+      sessionId: 'pi-session-run-lifecycle',
+      sessionFile: '/repo/.pi/session.jsonl',
+      agent: {
+        state,
+        waitForIdle: vi.fn(async () => undefined),
+        hasQueuedMessages: vi.fn(() => false),
+      },
+      sessionManager: {
+        getEntries: vi.fn(() => []),
+        getLeafId: vi.fn(() => null),
+      },
+      abort: vi.fn(async () => undefined),
+      get isCompacting() {
+        return compacting
+      },
+      get isStreaming() {
+        return false
+      },
+    }
+
+    const overflowError = assistantMessage({
+      text: '',
+      stopReason: 'error',
+      errorMessage: 'context overflow',
+    })
+    const recoveredAssistant = assistantMessage({
+      text: 'Recovered after compact',
+      stopReason: 'stop',
+    })
+
+    const payload: HydratedAgentSendPayload = {
+      text: 'Analyze and continue',
+      thinkingLevel: 'high',
+      attachments: [],
+    }
+
+    const result = await runSubscribedPiOperation({
+      runInput: runInput(payload),
+      session: session as unknown as AgentSession,
+      unsubscribe: vi.fn(),
+      abortWarning: 'abort failed',
+      preAbortWarning: 'pre-abort failed',
+      operation: async () => {
+        messages.push(overflowError)
+        compacting = true
+
+        setTimeout(() => {
+          messages.pop()
+          messages.push(recoveredAssistant)
+          compacting = false
+        }, 40)
+      },
+      buildErrorMessages: () => [],
+    })
+
+    expect('terminalError' in result ? result.terminalError : undefined).toBeUndefined()
+    expect(result.newMessages).toHaveLength(2)
+    expect(result.newMessages[1]?.role).toBe('assistant')
+    expect(getMessageText(result.newMessages[1]!)).toBe('Recovered after compact')
+    expect(lifecycleMocks.disposeOpenWagglePiSession).toHaveBeenCalledWith(session)
+  })
+
+  it('calls Pi agent settlement methods with their original receiver', async () => {
+    const state: FakeAgentState = { messages: [] }
+    const agent = {
+      state,
+      idleWaits: 0,
+      steeringQueue: { hasItems: () => false },
+      followUpQueue: { hasItems: () => false },
+      async waitForIdle() {
+        this.idleWaits += 1
+      },
+      hasQueuedMessages() {
+        return this.steeringQueue.hasItems() || this.followUpQueue.hasItems()
+      },
+    }
+    const session: FakeSession = {
+      sessionId: 'pi-session-run-lifecycle',
+      sessionFile: '/repo/.pi/session.jsonl',
+      agent,
+      sessionManager: {
+        getEntries: vi.fn(() => []),
+        getLeafId: vi.fn(() => null),
+      },
+      abort: vi.fn(async () => undefined),
+      isCompacting: false,
+      isStreaming: false,
+    }
+
+    const payload: HydratedAgentSendPayload = {
+      text: 'Continue',
+      thinkingLevel: 'high',
+      attachments: [],
+    }
+
+    const result = await runSubscribedPiOperation({
+      runInput: runInput(payload),
+      session: session as unknown as AgentSession,
+      unsubscribe: vi.fn(),
+      abortWarning: 'abort failed',
+      preAbortWarning: 'pre-abort failed',
+      operation: async () => {
+        state.messages.push(
+          assistantMessage({
+            text: 'Finished',
+            stopReason: 'stop',
+          }),
+        )
+      },
+      buildErrorMessages: () => [],
+    })
+
+    expect('terminalError' in result ? result.terminalError : undefined).toBeUndefined()
+    expect(result.newMessages).toHaveLength(2)
+    expect(agent.idleWaits).toBeGreaterThan(0)
+  })
+})

--- a/src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle.unit.test.ts
+++ b/src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle.unit.test.ts
@@ -2,6 +2,7 @@ import type { AgentSession } from '@mariozechner/pi-coding-agent'
 import { getMessageText, type HydratedAgentSendPayload } from '@shared/types/agent'
 import { SessionId, SupportedModelId } from '@shared/types/brand'
 import type { SessionDetail } from '@shared/types/session'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentKernelRunInput } from '../../../../ports/agent-kernel-service'
 import { runSubscribedPiOperation } from '../run-lifecycle'
@@ -16,8 +17,10 @@ vi.mock('../../pi-session-lifecycle', () => ({
 }))
 
 interface FakeAgentState {
-  messages: unknown[]
+  messages: PiAgentMessage[]
 }
+
+type PiAgentMessage = AgentSession['agent']['state']['messages'][number]
 
 interface FakeSession {
   readonly sessionId: string
@@ -64,13 +67,30 @@ function assistantMessage(input: {
   readonly text: string
   readonly stopReason: 'stop' | 'error'
   readonly errorMessage?: string
-}) {
+}): PiAgentMessage {
   return {
     role: 'assistant',
     content: [{ type: 'text', text: input.text }],
+    api: 'openai-responses',
+    provider: 'openai-codex',
     model: 'openai/gpt-5.5',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
     stopReason: input.stopReason,
     ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+    timestamp: Date.now(),
   }
 }
 
@@ -80,7 +100,7 @@ describe('run lifecycle settlement', () => {
   })
 
   it('waits for delayed post-run recovery updates before snapshot capture', async () => {
-    const messages: unknown[] = []
+    const messages: PiAgentMessage[] = []
     let compacting = false
     const state: FakeAgentState = { messages }
 
@@ -123,7 +143,7 @@ describe('run lifecycle settlement', () => {
 
     const result = await runSubscribedPiOperation({
       runInput: runInput(payload),
-      session: session as unknown as AgentSession,
+      session: fromPartial<AgentSession>(session),
       unsubscribe: vi.fn(),
       abortWarning: 'abort failed',
       preAbortWarning: 'pre-abort failed',
@@ -142,8 +162,11 @@ describe('run lifecycle settlement', () => {
 
     expect('terminalError' in result ? result.terminalError : undefined).toBeUndefined()
     expect(result.newMessages).toHaveLength(2)
-    expect(result.newMessages[1]?.role).toBe('assistant')
-    expect(getMessageText(result.newMessages[1]!)).toBe('Recovered after compact')
+    const recoveredMessage = result.newMessages[1]
+    expect(recoveredMessage?.role).toBe('assistant')
+    expect(recoveredMessage ? getMessageText(recoveredMessage) : null).toBe(
+      'Recovered after compact',
+    )
     expect(lifecycleMocks.disposeOpenWagglePiSession).toHaveBeenCalledWith(session)
   })
 
@@ -182,7 +205,7 @@ describe('run lifecycle settlement', () => {
 
     const result = await runSubscribedPiOperation({
       runInput: runInput(payload),
-      session: session as unknown as AgentSession,
+      session: fromPartial<AgentSession>(session),
       unsubscribe: vi.fn(),
       abortWarning: 'abort failed',
       preAbortWarning: 'pre-abort failed',

--- a/src/main/adapters/pi/agent-kernel/__tests__/run-orchestration.test-utils.ts
+++ b/src/main/adapters/pi/agent-kernel/__tests__/run-orchestration.test-utils.ts
@@ -48,7 +48,13 @@ export interface FakePiHarness {
 export interface FakeRunSession {
   readonly sessionId: string
   readonly sessionFile: string
-  readonly agent: { readonly state: { readonly messages: unknown[] } }
+  readonly agent: {
+    readonly state: { readonly messages: unknown[] }
+    readonly waitForIdle: () => Promise<void>
+    readonly hasQueuedMessages: () => boolean
+  }
+  readonly isCompacting: boolean
+  readonly isStreaming: boolean
   readonly sessionManager: {
     readonly buildSessionContext: () => { readonly messages: readonly unknown[] }
     readonly getEntries: () => readonly unknown[]
@@ -140,7 +146,13 @@ export function createFakeSession(
   return {
     sessionId: 'pi-session-1',
     sessionFile: '/repo/.pi/session.jsonl',
-    agent: { state: { messages } },
+    agent: {
+      state: { messages },
+      waitForIdle: vi.fn(async () => undefined),
+      hasQueuedMessages: vi.fn(() => false),
+    },
+    isCompacting: false,
+    isStreaming: false,
     sessionManager: {
       buildSessionContext: () => ({ messages: [] }),
       getEntries: () => [],

--- a/src/main/adapters/pi/agent-kernel/__tests__/run-orchestration.unit.test.ts
+++ b/src/main/adapters/pi/agent-kernel/__tests__/run-orchestration.unit.test.ts
@@ -84,6 +84,8 @@ describe('Pi run orchestration', () => {
     })
     expect(session.subscribe).toHaveBeenCalledOnce()
     expect(session.prompt).toHaveBeenCalledWith('Run tests', undefined)
+    expect(session.agent.waitForIdle).toHaveBeenCalled()
+    expect(session.agent.hasQueuedMessages).toHaveBeenCalled()
     expect(result.newMessages.map((message) => message.role)).toEqual(['user', 'assistant'])
     expect(runMocks.disposeOpenWagglePiSession).toHaveBeenCalledWith(session)
   })
@@ -129,6 +131,8 @@ describe('Pi run orchestration', () => {
       expect.objectContaining({ customType: 'openwaggle.waggle.turn', display: false }),
       { triggerTurn: true, deliverAs: 'followUp' },
     )
+    expect(session.agent.waitForIdle).toHaveBeenCalled()
+    expect(session.agent.hasQueuedMessages).toHaveBeenCalled()
     expect(turnEvents).toEqual([
       { type: 'turn-start', turnNumber: 0, agentIndex: 0, agentLabel: 'Architect' },
       { type: 'turn-start', turnNumber: 1, agentIndex: 1, agentLabel: 'Reviewer' },

--- a/src/main/adapters/pi/agent-kernel/post-run-settlement.ts
+++ b/src/main/adapters/pi/agent-kernel/post-run-settlement.ts
@@ -1,0 +1,108 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent'
+import { logger } from './constants'
+
+const POST_RUN_SETTLE_POLL_MS = 25
+const POST_RUN_SETTLE_QUIET_MS = 150
+const POST_RUN_SETTLE_MAX_MS = 15_000
+const POST_RUN_IDLE_WAIT_SETTLED = 'settled'
+const POST_RUN_IDLE_WAIT_TIMED_OUT = 'timed-out'
+
+type PostRunIdleWaitResult = typeof POST_RUN_IDLE_WAIT_SETTLED | typeof POST_RUN_IDLE_WAIT_TIMED_OUT
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+function hasQueuedMessages(session: AgentSession) {
+  return session.agent.hasQueuedMessages()
+}
+
+function getPostRunSettleRemainingMs(startedAt: number) {
+  return Math.max(0, POST_RUN_SETTLE_MAX_MS - (Date.now() - startedAt))
+}
+
+async function waitForIdleWithin(
+  session: AgentSession,
+  timeoutMs: number,
+): Promise<PostRunIdleWaitResult> {
+  if (timeoutMs <= 0) {
+    return POST_RUN_IDLE_WAIT_TIMED_OUT
+  }
+
+  const idleSettled = session.agent
+    .waitForIdle()
+    .then((): PostRunIdleWaitResult => POST_RUN_IDLE_WAIT_SETTLED)
+  const idleTimedOut = wait(timeoutMs).then(
+    (): PostRunIdleWaitResult => POST_RUN_IDLE_WAIT_TIMED_OUT,
+  )
+  return Promise.race([idleSettled, idleTimedOut])
+}
+
+async function waitForNextSettlementPoll(startedAt: number) {
+  const remainingMs = getPostRunSettleRemainingMs(startedAt)
+  if (remainingMs <= 0) {
+    return false
+  }
+
+  await wait(Math.min(POST_RUN_SETTLE_POLL_MS, remainingMs))
+  return true
+}
+
+function digestMessage(value: unknown) {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function buildSessionPostRunFingerprint(session: AgentSession) {
+  const messages = session.agent.state.messages
+  const lastMessage = messages.at(-1)
+  return [
+    messages.length,
+    digestMessage(lastMessage),
+    session.isCompacting ? 'compacting' : 'idle',
+    session.isStreaming ? 'streaming' : 'ready',
+    hasQueuedMessages(session) ? 'queued' : 'drained',
+  ].join('|')
+}
+
+export async function waitForPostRunSettlement(session: AgentSession) {
+  const startedAt = Date.now()
+  let lastChangedAt = startedAt
+  let lastFingerprint = buildSessionPostRunFingerprint(session)
+
+  while (getPostRunSettleRemainingMs(startedAt) > 0) {
+    const idleWaitResult = await waitForIdleWithin(session, getPostRunSettleRemainingMs(startedAt))
+    if (idleWaitResult === POST_RUN_IDLE_WAIT_TIMED_OUT) {
+      break
+    }
+
+    const fingerprint = buildSessionPostRunFingerprint(session)
+    const hasPendingWork = session.isCompacting || session.isStreaming || hasQueuedMessages(session)
+    const changed = fingerprint !== lastFingerprint
+
+    if (changed || hasPendingWork) {
+      lastFingerprint = fingerprint
+      lastChangedAt = Date.now()
+      await waitForNextSettlementPoll(startedAt)
+      continue
+    }
+
+    if (Date.now() - lastChangedAt >= POST_RUN_SETTLE_QUIET_MS) {
+      return
+    }
+
+    await waitForNextSettlementPoll(startedAt)
+  }
+
+  logger.warn('Timed out waiting for Pi post-run settlement before snapshot capture', {
+    maxWaitMs: POST_RUN_SETTLE_MAX_MS,
+    isCompacting: session.isCompacting,
+    isStreaming: session.isStreaming,
+    queuedMessages: hasQueuedMessages(session),
+  })
+}

--- a/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
+++ b/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
@@ -24,12 +24,9 @@ import {
   disposeOpenWagglePiSession,
 } from '../pi-session-lifecycle'
 import { logger } from './constants'
+import { waitForPostRunSettlement } from './post-run-settlement'
 import { createSessionManagerForSession } from './session-manager'
 import { projectPiSessionSnapshot } from './session-projection'
-
-const POST_RUN_SETTLE_POLL_MS = 25
-const POST_RUN_SETTLE_QUIET_MS = 150
-const POST_RUN_SETTLE_MAX_MS = 15_000
 
 export interface PiRunSessionRuntime {
   readonly model: PiModel
@@ -102,87 +99,20 @@ function createAbortListener(session: AgentSession, warning: string) {
 async function abortPiSession(session: AgentSession, warning: string) {
   await session.abort().catch((error) => {
     logger.warn(warning, {
-      error: error instanceof Error ? error.message : String(error),
+      error: describeError(error),
     })
   })
 }
 
-function wait(ms: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
-
-function hasQueuedMessages(session: AgentSession) {
-  return session.agent.hasQueuedMessages()
-}
-
-async function waitForIdle(session: AgentSession) {
-  await session.agent.waitForIdle()
-}
-
-function digestMessage(value: unknown) {
-  try {
-    return JSON.stringify(value)
-  } catch {
-    return String(value)
-  }
-}
-
-function buildSessionPostRunFingerprint(session: AgentSession) {
-  const messages = session.agent.state.messages
-  const lastMessage = messages.at(-1)
-  return [
-    messages.length,
-    digestMessage(lastMessage),
-    session.isCompacting ? 'compacting' : 'idle',
-    session.isStreaming ? 'streaming' : 'ready',
-    hasQueuedMessages(session) ? 'queued' : 'drained',
-  ].join('|')
-}
-
-async function waitForPostRunSettlement(session: AgentSession, signal: AbortSignal) {
-  const startedAt = Date.now()
-  let lastChangedAt = startedAt
-  let lastFingerprint = buildSessionPostRunFingerprint(session)
-
-  while (Date.now() - startedAt < POST_RUN_SETTLE_MAX_MS) {
-    await waitForIdle(session)
-    if (signal.aborted) {
-      return
-    }
-
-    const fingerprint = buildSessionPostRunFingerprint(session)
-    const hasPendingWork = session.isCompacting || session.isStreaming || hasQueuedMessages(session)
-    const changed = fingerprint !== lastFingerprint
-
-    if (changed || hasPendingWork) {
-      lastFingerprint = fingerprint
-      lastChangedAt = Date.now()
-      await wait(POST_RUN_SETTLE_POLL_MS)
-      continue
-    }
-
-    if (Date.now() - lastChangedAt >= POST_RUN_SETTLE_QUIET_MS) {
-      return
-    }
-
-    await wait(POST_RUN_SETTLE_POLL_MS)
-  }
-
-  logger.warn('Timed out waiting for Pi post-run settlement before snapshot capture', {
-    maxWaitMs: POST_RUN_SETTLE_MAX_MS,
-    isCompacting: session.isCompacting,
-    isStreaming: session.isStreaming,
-    queuedMessages: hasQueuedMessages(session),
-  })
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function buildSuccessfulRunResult(input: {
   readonly session: AgentSession
   readonly payload: HydratedAgentSendPayload
   readonly appended: readonly unknown[]
-  readonly signal: AbortSignal
+  readonly aborted: boolean
 }): AgentKernelRunResult {
   const terminalError = extractPiAssistantTerminalError(input.appended)
   const stopReason = getPiAssistantStopReason(input.appended)
@@ -192,7 +122,7 @@ function buildSuccessfulRunResult(input: {
     piSessionId: input.session.sessionId,
     piSessionFile: input.session.sessionFile,
     sessionSnapshot: projectPiSessionSnapshot(input.session),
-    ...(stopReason === 'aborted' || input.signal.aborted ? { aborted: true } : {}),
+    ...(stopReason === 'aborted' || input.aborted ? { aborted: true } : {}),
     ...(terminalError ? { terminalError } : {}),
   }
 }
@@ -245,6 +175,9 @@ export async function runSubscribedPiOperation(input: {
 }) {
   const abortListener = createAbortListener(input.session, input.abortWarning)
   let previousMessageCount = input.session.agent.state.messages.length
+  let abortListenerAttached = false
+  let operationAborted = false
+  let settlementAttempted = false
 
   if (input.runInput.signal.aborted) {
     const result = await abortPreCancelledRun(input.session, input.preAbortWarning)
@@ -254,24 +187,62 @@ export async function runSubscribedPiOperation(input: {
   }
 
   input.runInput.signal.addEventListener('abort', abortListener, { once: true })
+  abortListenerAttached = true
 
   try {
     previousMessageCount = input.session.agent.state.messages.length
-    await input.operation()
-    await waitForPostRunSettlement(input.session, input.runInput.signal)
+    let operationFailed = false
+    let operationError: unknown
+
+    try {
+      await input.operation()
+    } catch (error) {
+      operationFailed = true
+      operationError = error
+    }
+
+    operationAborted = input.runInput.signal.aborted
+    input.runInput.signal.removeEventListener('abort', abortListener)
+    abortListenerAttached = false
+
+    settlementAttempted = true
+    await waitForPostRunSettlement(input.session)
     const appended = input.session.agent.state.messages.slice(previousMessageCount)
+
+    if (operationFailed) {
+      const stopReason = getPiAssistantStopReason(appended)
+      const aborted = operationAborted || stopReason === 'aborted'
+      const message = describeError(operationError)
+      input.runInput.onEvent({
+        type: 'agent_end',
+        runId: input.runInput.runId,
+        reason: aborted ? 'aborted' : 'error',
+        ...(aborted ? {} : { error: { message } }),
+        timestamp: Date.now(),
+        model: input.runInput.model,
+      })
+      return buildFailedRunResult({
+        session: input.session,
+        newMessages: input.buildErrorMessages(appended),
+        aborted,
+        message,
+      })
+    }
+
     return buildSuccessfulRunResult({
       session: input.session,
       payload: input.runInput.payload,
       appended,
-      signal: input.runInput.signal,
+      aborted: operationAborted,
     })
   } catch (error) {
-    await waitForPostRunSettlement(input.session, input.runInput.signal)
+    if (!settlementAttempted) {
+      await waitForPostRunSettlement(input.session)
+    }
     const appended = input.session.agent.state.messages.slice(previousMessageCount)
     const stopReason = getPiAssistantStopReason(appended)
-    const aborted = input.runInput.signal.aborted || stopReason === 'aborted'
-    const message = error instanceof Error ? error.message : String(error)
+    const aborted = operationAborted || stopReason === 'aborted'
+    const message = describeError(error)
     input.runInput.onEvent({
       type: 'agent_end',
       runId: input.runInput.runId,
@@ -287,7 +258,9 @@ export async function runSubscribedPiOperation(input: {
       message,
     })
   } finally {
-    input.runInput.signal.removeEventListener('abort', abortListener)
+    if (abortListenerAttached) {
+      input.runInput.signal.removeEventListener('abort', abortListener)
+    }
     input.unsubscribe()
     await disposeOpenWagglePiSession(input.session)
   }

--- a/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
+++ b/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
@@ -114,15 +114,11 @@ function wait(ms: number) {
 }
 
 function hasQueuedMessages(session: AgentSession) {
-  const agent = session.agent as { hasQueuedMessages?: () => boolean }
-  return typeof agent.hasQueuedMessages === 'function' ? agent.hasQueuedMessages() : false
+  return session.agent.hasQueuedMessages()
 }
 
 async function waitForIdle(session: AgentSession) {
-  const agent = session.agent as { waitForIdle?: () => Promise<void> }
-  if (typeof agent.waitForIdle === 'function') {
-    await agent.waitForIdle()
-  }
+  await session.agent.waitForIdle()
 }
 
 function digestMessage(value: unknown) {

--- a/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
+++ b/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
@@ -27,6 +27,10 @@ import { logger } from './constants'
 import { createSessionManagerForSession } from './session-manager'
 import { projectPiSessionSnapshot } from './session-projection'
 
+const POST_RUN_SETTLE_POLL_MS = 25
+const POST_RUN_SETTLE_QUIET_MS = 150
+const POST_RUN_SETTLE_MAX_MS = 15_000
+
 export interface PiRunSessionRuntime {
   readonly model: PiModel
   readonly session: AgentSession
@@ -100,6 +104,81 @@ async function abortPiSession(session: AgentSession, warning: string) {
     logger.warn(warning, {
       error: error instanceof Error ? error.message : String(error),
     })
+  })
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+function hasQueuedMessages(session: AgentSession) {
+  const agent = session.agent as { hasQueuedMessages?: () => boolean }
+  return typeof agent.hasQueuedMessages === 'function' ? agent.hasQueuedMessages() : false
+}
+
+async function waitForIdle(session: AgentSession) {
+  const agent = session.agent as { waitForIdle?: () => Promise<void> }
+  if (typeof agent.waitForIdle === 'function') {
+    await agent.waitForIdle()
+  }
+}
+
+function digestMessage(value: unknown) {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function buildSessionPostRunFingerprint(session: AgentSession) {
+  const messages = session.agent.state.messages
+  const lastMessage = messages.at(-1)
+  return [
+    messages.length,
+    digestMessage(lastMessage),
+    session.isCompacting ? 'compacting' : 'idle',
+    session.isStreaming ? 'streaming' : 'ready',
+    hasQueuedMessages(session) ? 'queued' : 'drained',
+  ].join('|')
+}
+
+async function waitForPostRunSettlement(session: AgentSession, signal: AbortSignal) {
+  const startedAt = Date.now()
+  let lastChangedAt = startedAt
+  let lastFingerprint = buildSessionPostRunFingerprint(session)
+
+  while (Date.now() - startedAt < POST_RUN_SETTLE_MAX_MS) {
+    await waitForIdle(session)
+    if (signal.aborted) {
+      return
+    }
+
+    const fingerprint = buildSessionPostRunFingerprint(session)
+    const hasPendingWork = session.isCompacting || session.isStreaming || hasQueuedMessages(session)
+    const changed = fingerprint !== lastFingerprint
+
+    if (changed || hasPendingWork) {
+      lastFingerprint = fingerprint
+      lastChangedAt = Date.now()
+      await wait(POST_RUN_SETTLE_POLL_MS)
+      continue
+    }
+
+    if (Date.now() - lastChangedAt >= POST_RUN_SETTLE_QUIET_MS) {
+      return
+    }
+
+    await wait(POST_RUN_SETTLE_POLL_MS)
+  }
+
+  logger.warn('Timed out waiting for Pi post-run settlement before snapshot capture', {
+    maxWaitMs: POST_RUN_SETTLE_MAX_MS,
+    isCompacting: session.isCompacting,
+    isStreaming: session.isStreaming,
+    queuedMessages: hasQueuedMessages(session),
   })
 }
 
@@ -183,6 +262,7 @@ export async function runSubscribedPiOperation(input: {
   try {
     previousMessageCount = input.session.agent.state.messages.length
     await input.operation()
+    await waitForPostRunSettlement(input.session, input.runInput.signal)
     const appended = input.session.agent.state.messages.slice(previousMessageCount)
     return buildSuccessfulRunResult({
       session: input.session,
@@ -191,6 +271,7 @@ export async function runSubscribedPiOperation(input: {
       signal: input.runInput.signal,
     })
   } catch (error) {
+    await waitForPostRunSettlement(input.session, input.runInput.signal)
     const appended = input.session.agent.state.messages.slice(previousMessageCount)
     const stopReason = getPiAssistantStopReason(appended)
     const aborted = input.runInput.signal.aborted || stopReason === 'aborted'


### PR DESCRIPTION
## Summary

Fixes two related Pi run lifecycle regressions:

- Waits for delayed Pi post-run settlement before capturing appended messages and persisting the session snapshot. This prevents automatic/manual compaction or overflow recovery from being missed when Pi finishes the initial prompt before the delayed compaction/retry state has settled.
- Preserves the Pi `Agent` receiver when checking queued messages and waiting for idle. The previous implementation detached methods such as `hasQueuedMessages()`, which caused packaged runs to fail with `Cannot read properties of undefined (reading 'steeringQueue')` and surface as generic `Something went wrong`.

## Root Cause

`runSubscribedPiOperation` captured appended messages and the projected snapshot immediately after `session.prompt()` returned. Pi can still update state asynchronously during post-run auto-compaction/overflow recovery, so OpenWaggle could persist a stale snapshot and report the wrong terminal result.

The first fix introduced a settlement loop, but it initially called Pi agent methods as detached functions. Pi's `hasQueuedMessages()` depends on `this.steeringQueue`, so the packaged app crashed after a run completed.

## Validation

- `pnpm typecheck`
- `pnpm test:unit:raw src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle.unit.test.ts`
- `pnpm test:unit:raw src/main/adapters/pi/agent-kernel/__tests__/run-orchestration.unit.test.ts src/main/adapters/pi/agent-kernel/__tests__/session-operations.unit.test.ts src/main/application/__tests__/agent-session-service.unit.test.ts src/main/store/__tests__/session-details-compaction.integration.test.ts src/main/adapters/pi/agent-kernel/__tests__/run-lifecycle.unit.test.ts`
- Clean unsigned mac arm64 package built successfully for local testing outside the repository output path.