### PR TITLE
chore: trim .fallowrc (fallow 2.84.0 handles these natively)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,15 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
   "entry": [
-    "electron.vite.config.ts",
-    "src/main/index.ts",
-    "src/preload/index.ts",
-    "src/renderer/src/main.tsx",
-    "src/renderer/src/**/*.d.ts",
-    "src/shared/types/**/*.d.ts",
-    "scripts/**/*.ts",
-    "vitest.*.config.ts",
-    "playwright.config.ts"
+    "src/renderer/src/main.tsx"
   ],
   "ignorePatterns": ["out/**", "dist/**", "release/**", "node_modules/**"],
   "ignoreDependencies": [
@@ -22,9 +14,7 @@
     "jiti",
     // Packaged Electron updater resolves debug's `require("ms")` from the
     // app-level node_modules inside app.asar.
-    "ms",
-    "node:sqlite",
-    "tailwindcss"
+    "ms"
   ],
   "ignoreDependencyOverrides": [
     { "package": "@tanstack/history", "source": "package.json" },
@@ -49,24 +39,6 @@
     "ignoreImports": true,
     "minTokens": 100
   },
-  "usedClassMembers": [
-    {
-      "extends": "DecoratorNode",
-      "members": [
-        "clone",
-        "createDOM",
-        "decorate",
-        "exportDOM",
-        "exportJSON",
-        "getTextContent",
-        "getType",
-        "importDOM",
-        "importJSON",
-        "isInline",
-        "updateDOM"
-      ]
-    }
-  ],
   "health": {
     "maxCrap": 100
   },


### PR DESCRIPTION
fallow 2.84.0 lets this `.fallowrc.jsonc` shrink with no change in findings (verified: identical results before and after).

Removed:
- the whole `usedClassMembers` Lexical `DecoratorNode` block: node lifecycle members (`getType`, `clone`, `exportJSON`, etc.) are now auto-credited by the built-in Lexical plugin (since 2.81.0)
- `node:sqlite` and `tailwindcss` from `ignoreDependencies`: `node:sqlite` is a recognized Node builtin, and `tailwindcss` is now credited from its use in `electron.vite.config.ts`
- the `electron.vite.config.ts` / `src/main/index.ts` / `src/preload/index.ts` entries plus the `*.d.ts` / `scripts/**` / `vitest.*.config.ts` / `playwright.config.ts` entry globs: electron-vite main/preload entries are auto-detected (since 2.82.0), declaration files are reachability roots, and the test/script configs are picked up by their plugins. `src/renderer/src/main.tsx` stays (the renderer HTML entry isn't auto-detected)

Kept everything else: the 6 remaining `ignoreDependencies` are genuinely-unused-from-source deps fallow correctly flags, and `rules.duplicate-exports: off` still suppresses the legitimate TanStack `Route` re-export contract.

Refs #110.
