### PR TITLE
[codex] Fix Fallow complexity findings

### DIFF
--- a/packages/pi-waggle/package.json
+++ b/packages/pi-waggle/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "@openwaggle/waggle-core": "workspace:*"
   },
+  "devDependencies": {
+    "@total-typescript/shoehorn": "0.1.2"
+  },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-tui": "*"

--- a/packages/pi-waggle/src/default-agent-editor.ts
+++ b/packages/pi-waggle/src/default-agent-editor.ts
@@ -77,6 +77,95 @@ async function editAgentModel(input: {
   return concrete ?? input.agent.model
 }
 
+interface AgentEditMenu {
+  readonly modelBindingLabel: string
+  readonly options: string[]
+}
+
+type AgentEditResult =
+  | {
+      readonly action: 'continue'
+      readonly agent: WaggleAgentSlot
+    }
+  | {
+      readonly action: 'done'
+      readonly agent: WaggleAgentSlot
+    }
+
+function agentEditMenu(ctx: ExtensionContext, agent: WaggleAgentSlot): AgentEditMenu {
+  const modelBindingLabel = isWaggleInheritedModel(agent.model)
+    ? 'Use standard-mode model — active'
+    : 'Use standard-mode model — switch from pinned'
+
+  return {
+    modelBindingLabel,
+    options: [
+      `Edit label — ${agent.label}`,
+      `Edit role prompt — ${normalizePromptPreview(agent.roleDescription)}`,
+      `Change model — ${effectiveModelLabel(ctx, agent.model)}`,
+      modelBindingLabel,
+      `Change color — ${agent.color}`,
+      'Back',
+    ],
+  }
+}
+
+async function editSelectedAgentField(input: {
+  readonly ctx: ExtensionCommandContext
+  readonly agent: WaggleAgentSlot
+  readonly selected: string | undefined
+  readonly modelBindingLabel: string
+}): Promise<AgentEditResult> {
+  if (!input.selected || input.selected === 'Back') {
+    return { action: 'done', agent: input.agent }
+  }
+
+  if (input.selected.startsWith('Edit label')) {
+    const label = await promptPrefilledText({
+      ctx: input.ctx,
+      title: `Agent label for ${input.agent.label}`,
+      currentValue: input.agent.label,
+    })
+    return label === null
+      ? { action: 'done', agent: input.agent }
+      : { action: 'continue', agent: { ...input.agent, label } }
+  }
+
+  if (input.selected.startsWith('Edit role prompt')) {
+    const roleDescription = await promptLongText({
+      ctx: input.ctx,
+      title: `Role prompt for ${input.agent.label}`,
+      currentValue: input.agent.roleDescription,
+    })
+    return roleDescription === null
+      ? { action: 'done', agent: input.agent }
+      : { action: 'continue', agent: { ...input.agent, roleDescription } }
+  }
+
+  if (input.selected.startsWith('Change model')) {
+    return {
+      action: 'continue',
+      agent: {
+        ...input.agent,
+        model: await editAgentModel({ ctx: input.ctx, agent: input.agent }),
+      },
+    }
+  }
+
+  if (input.selected === input.modelBindingLabel) {
+    return { action: 'continue', agent: { ...input.agent, model: WAGGLE_INHERIT_MODEL } }
+  }
+
+  if (!input.selected.startsWith('Change color')) {
+    return { action: 'continue', agent: input.agent }
+  }
+
+  const color = await promptColor(input.ctx, input.agent.color)
+  return color === null
+    ? { action: 'done', agent: input.agent }
+    : { action: 'continue', agent: { ...input.agent, color } }
+}
+
 export async function editAgentSlot(input: {
   readonly ctx: ExtensionCommandContext
   readonly agent: WaggleAgentSlot
@@ -85,52 +174,17 @@ export async function editAgentSlot(input: {
 
   let agent = input.agent
   while (true) {
-    const modelBindingLabel = isWaggleInheritedModel(agent.model)
-      ? 'Use standard-mode model — active'
-      : 'Use standard-mode model — switch from pinned'
-    const selected = await input.ctx.ui.select(`Edit Waggle agent — ${agent.label}`, [
-      `Edit label — ${agent.label}`,
-      `Edit role prompt — ${normalizePromptPreview(agent.roleDescription)}`,
-      `Change model — ${effectiveModelLabel(input.ctx, agent.model)}`,
-      modelBindingLabel,
-      `Change color — ${agent.color}`,
-      'Back',
-    ])
+    const menu = agentEditMenu(input.ctx, agent)
+    const selected = await input.ctx.ui.select(`Edit Waggle agent — ${agent.label}`, menu.options)
+    const result = await editSelectedAgentField({
+      ctx: input.ctx,
+      agent,
+      selected,
+      modelBindingLabel: menu.modelBindingLabel,
+    })
 
-    if (!selected || selected === 'Back') return agent
-    if (selected.startsWith('Edit label')) {
-      const label = await promptPrefilledText({
-        ctx: input.ctx,
-        title: `Agent label for ${agent.label}`,
-        currentValue: agent.label,
-      })
-      if (label === null) return agent
-      agent = { ...agent, label }
-      continue
-    }
-    if (selected.startsWith('Edit role prompt')) {
-      const roleDescription = await promptLongText({
-        ctx: input.ctx,
-        title: `Role prompt for ${agent.label}`,
-        currentValue: agent.roleDescription,
-      })
-      if (roleDescription === null) return agent
-      agent = { ...agent, roleDescription }
-      continue
-    }
-    if (selected.startsWith('Change model')) {
-      agent = { ...agent, model: await editAgentModel({ ctx: input.ctx, agent }) }
-      continue
-    }
-    if (selected === modelBindingLabel) {
-      agent = { ...agent, model: WAGGLE_INHERIT_MODEL }
-      continue
-    }
-    if (selected.startsWith('Change color')) {
-      const color = await promptColor(input.ctx, agent.color)
-      if (color === null) return agent
-      agent = { ...agent, color }
-    }
+    if (result.action === 'done') return result.agent
+    agent = result.agent
   }
 }
 

--- a/packages/pi-waggle/src/default-commands.ts
+++ b/packages/pi-waggle/src/default-commands.ts
@@ -7,8 +7,6 @@ import { openWaggleControlCenter } from './default-control-center'
 import { createPresetFromEditor, editPresetFromEditor } from './default-editors'
 import { loadPiWagglePresetLayers, resolvedPresetsForUi } from './presets'
 
-export type { SetDefaultPiWaggleRun, StartDefaultPiWaggleRun } from './default-command-types'
-
 export async function handleDefaultWaggleCommand(
   input: DefaultWaggleCommandInput & { readonly args: string },
 ) {

--- a/packages/pi-waggle/src/default-config-editors.ts
+++ b/packages/pi-waggle/src/default-config-editors.ts
@@ -31,6 +31,8 @@ const DEFAULT_SECOND_AGENT_ROLE =
   'Stress-test the plan for correctness, risks, and missing details.'
 const DEFAULT_STOP_CONDITION = 'consensus'
 const DEFAULT_MAX_TURNS_SAFETY = 8
+const ADVANCED_JSON_LABEL = 'Advanced JSON…'
+const DONE_LABEL = 'Done'
 
 function notify(ctx: ExtensionContext, message: string, type: 'info' | 'warning' | 'error') {
   if (ctx.hasUI) ctx.ui.notify(message, type)
@@ -154,6 +156,85 @@ export async function promptFullWaggleConfig(input: {
   } satisfies WaggleConfig
 }
 
+type GuidedConfigEditResult =
+  | {
+      readonly action: 'continue'
+      readonly config: WaggleConfig
+    }
+  | {
+      readonly action: 'done'
+      readonly config: WaggleConfig
+    }
+
+function guidedConfigOptions(ctx: ExtensionCommandContext, config: WaggleConfig) {
+  const [firstAgent, secondAgent] = config.agents
+  return [
+    `Edit ${agentMenuLabel(ctx, firstAgent)}`,
+    `Edit ${agentMenuLabel(ctx, secondAgent)}`,
+    `Set stop condition — ${config.stop.primary}`,
+    `Set max turns — ${String(config.stop.maxTurnsSafety)}`,
+    ADVANCED_JSON_LABEL,
+    DONE_LABEL,
+  ]
+}
+
+async function editSelectedConfigField(input: {
+  readonly ctx: ExtensionCommandContext
+  readonly config: WaggleConfig
+  readonly selected: string | undefined
+}): Promise<GuidedConfigEditResult> {
+  if (!input.selected || input.selected === DONE_LABEL) {
+    return { action: 'done', config: input.config }
+  }
+
+  const [firstAgent, secondAgent] = input.config.agents
+  if (input.selected.startsWith(`Edit ${firstAgent.label}`)) {
+    const nextAgent = await editAgentSlot({ ctx: input.ctx, agent: firstAgent })
+    return { action: 'continue', config: { ...input.config, agents: [nextAgent, secondAgent] } }
+  }
+
+  if (input.selected.startsWith(`Edit ${secondAgent.label}`)) {
+    const nextAgent = await editAgentSlot({ ctx: input.ctx, agent: secondAgent })
+    return { action: 'continue', config: { ...input.config, agents: [firstAgent, nextAgent] } }
+  }
+
+  if (input.selected.startsWith('Set stop condition')) {
+    const primary = await promptStopCondition(input.ctx, input.config.stop.primary)
+    const config = primary
+      ? { ...input.config, stop: { ...input.config.stop, primary } }
+      : input.config
+    return { action: 'continue', config }
+  }
+
+  if (input.selected.startsWith('Set max turns')) {
+    const config = await editMaxTurnsConfig(input.ctx, input.config)
+    return { action: 'continue', config }
+  }
+
+  if (input.selected !== ADVANCED_JSON_LABEL) {
+    return { action: 'continue', config: input.config }
+  }
+
+  const config = await editAdvancedJsonConfig(input.ctx, input.config)
+  return { action: 'continue', config }
+}
+
+async function editMaxTurnsConfig(ctx: ExtensionCommandContext, config: WaggleConfig) {
+  const rawMaxTurns = await promptPrefilledText({
+    ctx,
+    title: 'Set Waggle max turns',
+    currentValue: String(config.stop.maxTurnsSafety),
+  })
+  return rawMaxTurns === null
+    ? config
+    : { ...config, stop: { ...config.stop, maxTurnsSafety: parseMaxTurns(rawMaxTurns) } }
+}
+
+async function editAdvancedJsonConfig(ctx: ExtensionCommandContext, config: WaggleConfig) {
+  const edited = await ctx.ui.editor('Advanced Waggle config JSON', stringifyConfigJson(config))
+  return edited?.trim() ? parseEditedConfig(edited) : config
+}
+
 export async function editWaggleConfigGuided(input: {
   readonly ctx: ExtensionCommandContext
   readonly initialConfig: WaggleConfig
@@ -163,50 +244,10 @@ export async function editWaggleConfigGuided(input: {
 
   let config = input.initialConfig
   while (true) {
-    const [firstAgent, secondAgent] = config.agents
-    const selected = await input.ctx.ui.select(input.title, [
-      `Edit ${agentMenuLabel(input.ctx, firstAgent)}`,
-      `Edit ${agentMenuLabel(input.ctx, secondAgent)}`,
-      `Set stop condition — ${config.stop.primary}`,
-      `Set max turns — ${String(config.stop.maxTurnsSafety)}`,
-      'Advanced JSON…',
-      'Done',
-    ])
-
-    if (!selected || selected === 'Done') return config
-    if (selected.startsWith(`Edit ${firstAgent.label}`)) {
-      const nextAgent = await editAgentSlot({ ctx: input.ctx, agent: firstAgent })
-      config = { ...config, agents: [nextAgent, secondAgent] }
-      continue
-    }
-    if (selected.startsWith(`Edit ${secondAgent.label}`)) {
-      const nextAgent = await editAgentSlot({ ctx: input.ctx, agent: secondAgent })
-      config = { ...config, agents: [firstAgent, nextAgent] }
-      continue
-    }
-    if (selected.startsWith('Set stop condition')) {
-      const primary = await promptStopCondition(input.ctx, config.stop.primary)
-      if (primary) config = { ...config, stop: { ...config.stop, primary } }
-      continue
-    }
-    if (selected.startsWith('Set max turns')) {
-      const rawMaxTurns = await promptPrefilledText({
-        ctx: input.ctx,
-        title: 'Set Waggle max turns',
-        currentValue: String(config.stop.maxTurnsSafety),
-      })
-      if (rawMaxTurns !== null) {
-        config = { ...config, stop: { ...config.stop, maxTurnsSafety: parseMaxTurns(rawMaxTurns) } }
-      }
-      continue
-    }
-    if (selected === 'Advanced JSON…') {
-      const edited = await input.ctx.ui.editor(
-        'Advanced Waggle config JSON',
-        stringifyConfigJson(config),
-      )
-      if (edited?.trim()) config = parseEditedConfig(edited)
-    }
+    const selected = await input.ctx.ui.select(input.title, guidedConfigOptions(input.ctx, config))
+    const result = await editSelectedConfigField({ ctx: input.ctx, config, selected })
+    if (result.action === 'done') return result.config
+    config = result.config
   }
 }
 

--- a/packages/pi-waggle/src/default-preset-management.ts
+++ b/packages/pi-waggle/src/default-preset-management.ts
@@ -22,6 +22,7 @@ type PresetManagementNavigation = 'back' | 'close'
 
 const BACK_TO_PARENT: PresetManagementNavigation = 'back'
 const CLOSE_MENU: PresetManagementNavigation = 'close'
+const BACK_LABEL = 'Back'
 
 function notify(ctx: ExtensionContext, message: string, type: 'info' | 'warning' | 'error') {
   if (ctx.hasUI) ctx.ui.notify(message, type)
@@ -117,6 +118,48 @@ async function restoreHiddenPreset(input: {
   notify(input.ctx, `Restored built-in preset: ${selected.preset.name}`, 'info')
 }
 
+type PresetManagementResult =
+  | {
+      readonly action: 'continue'
+    }
+  | {
+      readonly action: 'return'
+      readonly navigation: PresetManagementNavigation
+    }
+
+async function handlePresetManagementSelection(input: {
+  readonly ctx: ExtensionCommandContext
+  readonly selected: string | undefined
+  readonly layers: Awaited<ReturnType<typeof loadPiWagglePresetLayers>>
+  readonly hiddenPresets: readonly PiWaggleHiddenBuiltInPreset[]
+  readonly editPreset: () => Promise<void>
+}): Promise<PresetManagementResult> {
+  if (input.selected === BACK_LABEL) {
+    return { action: 'return', navigation: BACK_TO_PARENT }
+  }
+
+  if (!input.selected) {
+    return { action: 'return', navigation: CLOSE_MENU }
+  }
+
+  if (input.selected === MANAGE_EDIT_LABEL) {
+    await input.editPreset()
+    return { action: 'continue' }
+  }
+
+  if (input.selected === MANAGE_DELETE_LABEL) {
+    const preset = await selectPresetToDelete(input.ctx, resolvedPresetsForUi(input.layers))
+    if (preset) await deletePreset({ ctx: input.ctx, preset })
+    return { action: 'continue' }
+  }
+
+  if (input.selected === MANAGE_RESTORE_LABEL) {
+    await restoreHiddenPreset({ ctx: input.ctx, hiddenPresets: input.hiddenPresets })
+  }
+
+  return { action: 'continue' }
+}
+
 export async function managePresets(input: {
   readonly ctx: ExtensionCommandContext
   readonly editPreset: () => Promise<void>
@@ -130,22 +173,16 @@ export async function managePresets(input: {
       MANAGE_EDIT_LABEL,
       MANAGE_DELETE_LABEL,
       ...(hiddenPresets.length > 0 ? [MANAGE_RESTORE_LABEL] : []),
-      'Back',
+      BACK_LABEL,
     ]
     const selected = await input.ctx.ui.select('Manage Waggle presets', options)
-    if (selected === 'Back') return BACK_TO_PARENT
-    if (!selected) return CLOSE_MENU
-    if (selected === MANAGE_EDIT_LABEL) {
-      await input.editPreset()
-      continue
-    }
-    if (selected === MANAGE_DELETE_LABEL) {
-      const preset = await selectPresetToDelete(input.ctx, resolvedPresetsForUi(layers))
-      if (preset) await deletePreset({ ctx: input.ctx, preset })
-      continue
-    }
-    if (selected === MANAGE_RESTORE_LABEL) {
-      await restoreHiddenPreset({ ctx: input.ctx, hiddenPresets })
-    }
+    const result = await handlePresetManagementSelection({
+      ctx: input.ctx,
+      selected,
+      layers,
+      hiddenPresets,
+      editPreset: input.editPreset,
+    })
+    if (result.action === 'return') return result.navigation
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,10 @@ importers:
       '@openwaggle/waggle-core':
         specifier: workspace:*
         version: link:../waggle-core
+    devDependencies:
+      '@total-typescript/shoehorn':
+        specifier: 0.1.2
+        version: 0.1.2
 
   packages/waggle-core: {}
 

--- a/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
+++ b/src/main/adapters/pi/agent-kernel/run-lifecycle.ts
@@ -141,6 +141,94 @@ function buildFailedRunResult(input: {
   }
 }
 
+type PiOperationOutcome =
+  | {
+      readonly status: 'completed'
+    }
+  | {
+      readonly status: 'failed'
+      readonly error: unknown
+    }
+
+async function runPiOperation(operation: () => Promise<void>): Promise<PiOperationOutcome> {
+  try {
+    await operation()
+    return { status: 'completed' }
+  } catch (error) {
+    return { status: 'failed', error }
+  }
+}
+
+async function collectSettledPiMessages(session: AgentSession, previousMessageCount: number) {
+  await waitForPostRunSettlement(session)
+  return session.agent.state.messages.slice(previousMessageCount)
+}
+
+function emitFailedRunEnd(input: {
+  readonly runInput: AgentKernelRunInput
+  readonly aborted: boolean
+  readonly message: string
+}) {
+  input.runInput.onEvent({
+    type: 'agent_end',
+    runId: input.runInput.runId,
+    reason: input.aborted ? 'aborted' : 'error',
+    ...(input.aborted ? {} : { error: { message: input.message } }),
+    timestamp: Date.now(),
+    model: input.runInput.model,
+  })
+}
+
+function buildFailedSubscribedRunResult(input: {
+  readonly session: AgentSession
+  readonly runInput: AgentKernelRunInput
+  readonly appended: readonly unknown[]
+  readonly operationAborted: boolean
+  readonly error: unknown
+  readonly buildErrorMessages: (appended: readonly unknown[]) => readonly Message[]
+}) {
+  const stopReason = getPiAssistantStopReason(input.appended)
+  const aborted = input.operationAborted || stopReason === 'aborted'
+  const message = describeError(input.error)
+
+  emitFailedRunEnd({
+    runInput: input.runInput,
+    aborted,
+    message,
+  })
+
+  return buildFailedRunResult({
+    session: input.session,
+    newMessages: input.buildErrorMessages(input.appended),
+    aborted,
+    message,
+  })
+}
+
+async function buildFailedRunAfterSettlement(input: {
+  readonly session: AgentSession
+  readonly runInput: AgentKernelRunInput
+  readonly previousMessageCount: number
+  readonly operationAborted: boolean
+  readonly settlementAttempted: boolean
+  readonly error: unknown
+  readonly buildErrorMessages: (appended: readonly unknown[]) => readonly Message[]
+}) {
+  if (!input.settlementAttempted) {
+    await waitForPostRunSettlement(input.session)
+  }
+
+  const appended = input.session.agent.state.messages.slice(input.previousMessageCount)
+  return buildFailedSubscribedRunResult({
+    session: input.session,
+    runInput: input.runInput,
+    appended,
+    operationAborted: input.operationAborted,
+    error: input.error,
+    buildErrorMessages: input.buildErrorMessages,
+  })
+}
+
 async function abortPreCancelledRun(session: AgentSession, warning: string) {
   await abortPiSession(session, warning)
   return {
@@ -191,41 +279,23 @@ export async function runSubscribedPiOperation(input: {
 
   try {
     previousMessageCount = input.session.agent.state.messages.length
-    let operationFailed = false
-    let operationError: unknown
-
-    try {
-      await input.operation()
-    } catch (error) {
-      operationFailed = true
-      operationError = error
-    }
+    const operationOutcome = await runPiOperation(input.operation)
 
     operationAborted = input.runInput.signal.aborted
     input.runInput.signal.removeEventListener('abort', abortListener)
     abortListenerAttached = false
 
     settlementAttempted = true
-    await waitForPostRunSettlement(input.session)
-    const appended = input.session.agent.state.messages.slice(previousMessageCount)
+    const appended = await collectSettledPiMessages(input.session, previousMessageCount)
 
-    if (operationFailed) {
-      const stopReason = getPiAssistantStopReason(appended)
-      const aborted = operationAborted || stopReason === 'aborted'
-      const message = describeError(operationError)
-      input.runInput.onEvent({
-        type: 'agent_end',
-        runId: input.runInput.runId,
-        reason: aborted ? 'aborted' : 'error',
-        ...(aborted ? {} : { error: { message } }),
-        timestamp: Date.now(),
-        model: input.runInput.model,
-      })
-      return buildFailedRunResult({
+    if (operationOutcome.status === 'failed') {
+      return buildFailedSubscribedRunResult({
         session: input.session,
-        newMessages: input.buildErrorMessages(appended),
-        aborted,
-        message,
+        runInput: input.runInput,
+        appended,
+        operationAborted,
+        error: operationOutcome.error,
+        buildErrorMessages: input.buildErrorMessages,
       })
     }
 
@@ -236,26 +306,14 @@ export async function runSubscribedPiOperation(input: {
       aborted: operationAborted,
     })
   } catch (error) {
-    if (!settlementAttempted) {
-      await waitForPostRunSettlement(input.session)
-    }
-    const appended = input.session.agent.state.messages.slice(previousMessageCount)
-    const stopReason = getPiAssistantStopReason(appended)
-    const aborted = operationAborted || stopReason === 'aborted'
-    const message = describeError(error)
-    input.runInput.onEvent({
-      type: 'agent_end',
-      runId: input.runInput.runId,
-      reason: aborted ? 'aborted' : 'error',
-      ...(aborted ? {} : { error: { message } }),
-      timestamp: Date.now(),
-      model: input.runInput.model,
-    })
-    return buildFailedRunResult({
+    return buildFailedRunAfterSettlement({
       session: input.session,
-      newMessages: input.buildErrorMessages(appended),
-      aborted,
-      message,
+      runInput: input.runInput,
+      previousMessageCount,
+      operationAborted,
+      settlementAttempted,
+      error,
+      buildErrorMessages: input.buildErrorMessages,
     })
   } finally {
     if (abortListenerAttached) {


### PR DESCRIPTION
## Summary

- Refactor Pi run-lifecycle failure handling so post-run settlement and failure result construction stay below Fallow complexity thresholds.
- Refactor `packages/pi-waggle` menu selection flows into smaller handlers for agent editing, guided config editing, and preset management.
- Declare `@total-typescript/shoehorn` in the `@openwaggle/pi-waggle` workspace test dependencies and remove unused command callback type re-exports.

## Validation

- `FALLOW_AGENT_SOURCE=codex pnpm --silent dlx fallow@2.84.0 --format json --quiet --explain`
- `pnpm check`
- `pnpm test:unit`
- `pnpm test:integration`