### PR TITLE
fix(release): normalize npm bootstrap registry state

### DIFF
--- a/scripts/__tests__/package-release-bootstrap-conflicts.unit.test.ts
+++ b/scripts/__tests__/package-release-bootstrap-conflicts.unit.test.ts
@@ -9,7 +9,7 @@ import {
 } from './package-release-bootstrap-test-helpers'
 
 describe('package release namespace bootstrap conflicts', () => {
-  it('refuses a bootstrap version assigned to latest before any mutation', async () => {
+  it('classifies npm automatic latest assignment as a resumable repair', async () => {
     const packageName = PACKAGE_NAMES[0]
     const overrides = new Map<string, BootstrapCommandResult>([
       [`npm view ${packageName} --json`, successful(JSON.stringify({ name: packageName }))],
@@ -45,14 +45,154 @@ describe('package release namespace bootstrap conflicts', () => {
     const { dependencies, requests } = createDependencies(overrides)
 
     const result = await runPackageReleaseBootstrap(
-      { args: ['--execute'], projectRoot: '/workspace/OpenWaggle' },
+      { args: [], projectRoot: '/workspace/OpenWaggle' },
       dependencies,
     )
 
-    expect(result.ok).toBe(false)
+    expect(result.ok).toBe(true)
     expect(result.packages[0]).toEqual({
       name: packageName,
-      nextAction: 'remove the conflicting latest tag before continuing',
+      nextAction: 'remove automatic bootstrap latest tag, then reassert package MFA',
+      state: 'pending',
+    })
+    expect(requests.filter((request) => request.mutates)).toEqual([])
+  })
+
+  it('accepts npm-normalized metadata when the placeholder tarball contains one file', async () => {
+    const packageName = PACKAGE_NAMES[0]
+    const overrides = new Map<string, BootstrapCommandResult>([
+      [`npm view ${packageName} --json`, successful(JSON.stringify({ name: packageName }))],
+      [
+        `npm view ${packageName}@0.0.0-bootstrap.0 --json`,
+        successful(
+          JSON.stringify({
+            dist: { fileCount: 1 },
+            name: packageName,
+            openwaggleNamespaceBootstrap: true,
+            version: '0.0.0-bootstrap.0',
+          }),
+        ),
+      ],
+      [
+        `npm view ${packageName} dist-tags --json`,
+        successful(JSON.stringify({ bootstrap: '0.0.0-bootstrap.0' })),
+      ],
+      [`npm access get status ${packageName} --json`, publicAccess(packageName)],
+      [`npm trust list ${packageName} --json`, successful()],
+    ])
+    const { dependencies } = createDependencies(overrides)
+
+    const result = await runPackageReleaseBootstrap(
+      { args: [], projectRoot: '/workspace/OpenWaggle' },
+      dependencies,
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.packages[0]).toEqual({
+      name: packageName,
+      nextAction: 'configure trusted publisher and finalize bootstrap',
+      state: 'pending',
+    })
+  })
+
+  it('refuses contradictory normalized file-count evidence', async () => {
+    const packageName = PACKAGE_NAMES[0]
+    const overrides = new Map<string, BootstrapCommandResult>([
+      [`npm view ${packageName} --json`, successful(JSON.stringify({ name: packageName }))],
+      [
+        `npm view ${packageName}@0.0.0-bootstrap.0 --json`,
+        successful(
+          JSON.stringify({
+            dist: { fileCount: 2 },
+            files: [],
+            name: packageName,
+            openwaggleNamespaceBootstrap: true,
+            version: '0.0.0-bootstrap.0',
+          }),
+        ),
+      ],
+    ])
+    const { dependencies, requests } = createDependencies(overrides)
+
+    const result = await runPackageReleaseBootstrap(
+      { args: [], projectRoot: '/workspace/OpenWaggle' },
+      dependencies,
+    )
+
+    expect(result.packages[0]).toEqual({
+      name: packageName,
+      nextAction: 'resolve conflicting bootstrap package metadata',
+      state: 'conflict',
+    })
+    expect(requests.filter((request) => request.mutates)).toEqual([])
+  })
+
+  it.each(['unexpected', {}])('refuses malformed normalized dist evidence: %j', async (dist) => {
+    const packageName = PACKAGE_NAMES[0]
+    const overrides = new Map<string, BootstrapCommandResult>([
+      [`npm view ${packageName} --json`, successful(JSON.stringify({ name: packageName }))],
+      [
+        `npm view ${packageName}@0.0.0-bootstrap.0 --json`,
+        successful(
+          JSON.stringify({
+            dist,
+            files: [],
+            name: packageName,
+            openwaggleNamespaceBootstrap: true,
+            version: '0.0.0-bootstrap.0',
+          }),
+        ),
+      ],
+    ])
+    const { dependencies, requests } = createDependencies(overrides)
+
+    const result = await runPackageReleaseBootstrap(
+      { args: [], projectRoot: '/workspace/OpenWaggle' },
+      dependencies,
+    )
+
+    expect(result.packages[0]?.state).toBe('conflict')
+    expect(requests.filter((request) => request.mutates)).toEqual([])
+  })
+
+  it('refuses unexpected deprecation metadata before repairing automatic latest', async () => {
+    const packageName = PACKAGE_NAMES[0]
+    const overrides = new Map<string, BootstrapCommandResult>([
+      [`npm view ${packageName} --json`, successful(JSON.stringify({ name: packageName }))],
+      [
+        `npm view ${packageName}@0.0.0-bootstrap.0 --json`,
+        successful(
+          JSON.stringify({
+            deprecated: 'unexpected',
+            files: [],
+            name: packageName,
+            openwaggleNamespaceBootstrap: true,
+            version: '0.0.0-bootstrap.0',
+          }),
+        ),
+      ],
+      [
+        `npm view ${packageName} dist-tags --json`,
+        successful(
+          JSON.stringify({
+            bootstrap: '0.0.0-bootstrap.0',
+            latest: '0.0.0-bootstrap.0',
+          }),
+        ),
+      ],
+      [`npm access get status ${packageName} --json`, publicAccess(packageName)],
+      [`npm trust list ${packageName} --json`, successful()],
+    ])
+    const { dependencies, requests } = createDependencies(overrides)
+
+    const result = await runPackageReleaseBootstrap(
+      { args: [], projectRoot: '/workspace/OpenWaggle' },
+      dependencies,
+    )
+
+    expect(result.packages[0]).toEqual({
+      name: packageName,
+      nextAction: 'resolve conflicting bootstrap deprecation metadata',
       state: 'conflict',
     })
     expect(requests.filter((request) => request.mutates)).toEqual([])

--- a/scripts/__tests__/package-release-bootstrap-execute.unit.test.ts
+++ b/scripts/__tests__/package-release-bootstrap-execute.unit.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { runPackageReleaseBootstrap, type BootstrapCommandResult } from '../package-release-bootstrap'
 import {
-  addCompatibleGithubState,
-  addCompatiblePackageState,
   commandKey,
   compatibleTrustConfiguration,
   compatibleRuleset,
@@ -13,35 +11,6 @@ import {
 } from './package-release-bootstrap-test-helpers'
 
 describe('package release namespace bootstrap execution', () => {
-  it('reasserts only the unverifiable package MFA setting for metadata-compatible state', async () => {
-    const overrides = new Map<string, BootstrapCommandResult>([
-      ['pnpm check', successful()],
-      [
-        'npm access list packages maintainer --json',
-        successful(
-          JSON.stringify(Object.fromEntries(PACKAGE_NAMES.map((name) => [name, 'read-write']))),
-        ),
-      ],
-    ])
-    addCompatiblePackageState(overrides)
-    addCompatibleGithubState(overrides)
-    for (const packageName of PACKAGE_NAMES) {
-      overrides.set(`npm access set mfa=publish ${packageName}`, successful())
-    }
-    const { dependencies, requests } = createDependencies(overrides)
-
-    const result = await runPackageReleaseBootstrap(
-      { args: ['--execute'], projectRoot: '/workspace/OpenWaggle' },
-      dependencies,
-    )
-
-    expect(result.ok).toBe(true)
-    expect(result.packages.every((item) => item.state === 'complete')).toBe(true)
-    expect(
-      requests.filter((request) => request.mutates).map(commandKey),
-    ).toEqual(PACKAGE_NAMES.map((name) => `npm access set mfa=publish ${name}`))
-  })
-
   it('revalidates namespace state after checks and before the first mutation', async () => {
     const packageName = PACKAGE_NAMES[0]
     const sequenceOverrides = new Map<string, BootstrapCommandResult[]>([
@@ -76,7 +45,7 @@ describe('package release namespace bootstrap execution', () => {
     expect(requests.filter((request) => request.mutates)).toEqual([])
   })
 
-  it('stops after publish when registry tags do not preserve bootstrap-only isolation', async () => {
+  it('repairs automatic latest and stops if registry verification still reports it', async () => {
     const packageName = PACKAGE_NAMES[0]
     const overrides = new Map<string, BootstrapCommandResult>([
       ['pnpm check', successful()],
@@ -134,6 +103,7 @@ describe('package release namespace bootstrap execution', () => {
     expect(requests.filter((request) => request.mutates).map(commandKey)).toEqual([
       'npm publish --tag bootstrap --access public --ignore-scripts',
       `npm access set mfa=publish ${packageName}`,
+      `npm dist-tag rm ${packageName} latest`,
       `npm access set mfa=publish ${packageName}`,
     ])
   })

--- a/scripts/__tests__/package-release-bootstrap-tag-repair.unit.test.ts
+++ b/scripts/__tests__/package-release-bootstrap-tag-repair.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { runPackageReleaseBootstrap, type BootstrapCommandResult } from '../package-release-bootstrap'
+import {
+  addCompatibleGithubState,
+  addCompatiblePackageState,
+  commandKey,
+  createDependencies,
+  PACKAGE_NAMES,
+  successful,
+} from './package-release-bootstrap-test-helpers'
+
+describe('package release namespace bootstrap tag repair', () => {
+  it('repairs automatic latest after MFA without recreating compatible trust', async () => {
+    const overrides = new Map<string, BootstrapCommandResult>([
+      ['pnpm check', successful()],
+      [
+        'npm access list packages maintainer --json',
+        successful(
+          JSON.stringify(Object.fromEntries(PACKAGE_NAMES.map((name) => [name, 'read-write']))),
+        ),
+      ],
+    ])
+    addCompatiblePackageState(overrides)
+    addCompatibleGithubState(overrides)
+    for (const packageName of PACKAGE_NAMES) {
+      overrides.set(`npm access set mfa=publish ${packageName}`, successful())
+    }
+    const firstPackage = PACKAGE_NAMES[0]
+    overrides.set(`npm dist-tag rm ${firstPackage} latest`, successful())
+    const automaticLatest = successful(
+      JSON.stringify({
+        bootstrap: '0.0.0-bootstrap.0',
+        latest: '0.0.0-bootstrap.0',
+      }),
+    )
+    const bootstrapOnly = successful(JSON.stringify({ bootstrap: '0.0.0-bootstrap.0' }))
+    const sequenceOverrides = new Map<string, BootstrapCommandResult[]>([
+      [
+        `npm view ${firstPackage} dist-tags --json`,
+        [automaticLatest, automaticLatest, automaticLatest, bootstrapOnly, bootstrapOnly],
+      ],
+    ])
+    const { dependencies, requests } = createDependencies(overrides, sequenceOverrides)
+
+    const result = await runPackageReleaseBootstrap(
+      { args: ['--execute'], projectRoot: '/workspace/OpenWaggle' },
+      dependencies,
+    )
+
+    expect(result.blockers).toEqual([])
+    expect(result.ok).toBe(true)
+    expect(result.packages.every((item) => item.state === 'complete')).toBe(true)
+    expect(requests.filter((request) => request.mutates).map(commandKey)).toEqual([
+      `npm access set mfa=publish ${firstPackage}`,
+      `npm dist-tag rm ${firstPackage} latest`,
+      ...PACKAGE_NAMES.slice(1).map((name) => `npm access set mfa=publish ${name}`),
+    ])
+  })
+})

--- a/scripts/package-release-bootstrap-execute.ts
+++ b/scripts/package-release-bootstrap-execute.ts
@@ -9,12 +9,14 @@ import {
 import {
   configureAndVerifyPackage,
   publishPlaceholder,
+  removeAutomaticBootstrapLatestTag,
   restrictPackagePublishing,
   verifyPublishedPlaceholder,
   verifyWriteAccess,
 } from './package-release-bootstrap-registry'
 import { inspectBootstrapPreflight } from './package-release-bootstrap-preflight'
 import {
+  CONTINUATION_BY_AUTOMATIC_LATEST_REPAIR,
   NEXT_CONFIGURE,
   NEXT_FINALIZE,
   NEXT_PUBLISH,
@@ -93,9 +95,29 @@ async function securePackage(
         restrictPackagePublishing(projectRoot, packageProgress.name, dependencies),
       )
       publishingRestricted = true
+      await removeAutomaticBootstrapLatestTag(
+        projectRoot,
+        packageProgress.name,
+        dependencies,
+      )
       await verifyPublishedPlaceholder(projectRoot, packageProgress.name, dependencies)
       await verifyWriteAccess(projectRoot, username, dependencies, [packageProgress.name])
       packageProgress.nextAction = NEXT_CONFIGURE
+    }
+    const continuationAfterTagRepair = CONTINUATION_BY_AUTOMATIC_LATEST_REPAIR.get(
+      packageProgress.nextAction,
+    )
+    if (continuationAfterTagRepair !== undefined) {
+      await restrictPackagePublishing(projectRoot, packageProgress.name, dependencies)
+      publishingRestricted = true
+      await removeAutomaticBootstrapLatestTag(
+        projectRoot,
+        packageProgress.name,
+        dependencies,
+      )
+      await verifyPublishedPlaceholder(projectRoot, packageProgress.name, dependencies)
+      await verifyWriteAccess(projectRoot, username, dependencies, [packageProgress.name])
+      packageProgress.nextAction = continuationAfterTagRepair
     }
     const createTrust = packageProgress.nextAction === NEXT_CONFIGURE
     const deprecate = createTrust || packageProgress.nextAction === NEXT_FINALIZE

--- a/scripts/package-release-bootstrap-model.ts
+++ b/scripts/package-release-bootstrap-model.ts
@@ -170,9 +170,18 @@ export function isCompatibleBootstrapRecord(value: unknown, packageName: string)
     return false
   }
 
-  return (
+  const hasDistMetadata = value.dist !== undefined
+  const distFileCount = isJsonObject(value.dist) ? value.dist.fileCount : undefined
+  const hasCompatibleDistMetadata = !hasDistMetadata || distFileCount === 1
+  const manifestHasNoFiles =
     isUnknownArray(value.files) &&
     value.files.length === 0 &&
+    hasCompatibleDistMetadata
+  const registryMetadataHasOnlyManifest =
+    value.files === undefined && distFileCount === 1
+
+  return (
+    (manifestHasNoFiles || registryMetadataHasOnlyManifest) &&
     BOOTSTRAP_FORBIDDEN_FIELDS.every((field) => value[field] === undefined)
   )
 }

--- a/scripts/package-release-bootstrap-preflight.ts
+++ b/scripts/package-release-bootstrap-preflight.ts
@@ -21,6 +21,7 @@ import {
   type JsonObject,
 } from './package-release-bootstrap-model'
 import {
+  AUTOMATIC_LATEST_REPAIR_BY_CONTINUATION,
   NEXT_CONFIGURE,
   NEXT_FINALIZE,
   NEXT_PUBLISH,
@@ -152,10 +153,16 @@ async function inspectPublishedPlaceholder(
     }),
     `npm view ${packageName} dist-tags`,
   )
-  if (isJsonObject(tags) && tags.latest === BOOTSTRAP_VERSION) {
-    return conflict(packageName, 'remove the conflicting latest tag before continuing')
+  const hasAutomaticLatest = isJsonObject(tags) && tags.latest === BOOTSTRAP_VERSION
+  if (hasAutomaticLatest) {
+    const tagsWithoutAutomaticLatest = Object.fromEntries(
+      Object.entries(tags).filter(([tag]) => tag !== 'latest'),
+    )
+    if (!hasCompatibleTags(tagsWithoutAutomaticLatest)) {
+      return conflict(packageName, 'resolve conflicting bootstrap dist-tags')
+    }
   }
-  if (!hasCompatibleTags(tags)) {
+  if (!hasAutomaticLatest && !hasCompatibleTags(tags)) {
     return conflict(packageName, 'resolve conflicting bootstrap dist-tags')
   }
   const access = await runRequired(dependencies, {
@@ -173,8 +180,12 @@ async function inspectPublishedPlaceholder(
   })
   const trust =
     trustOutput.length === 0 ? [] : parseJson(trustOutput, `npm trust list ${packageName}`)
+  const requiresDeprecation = needsBootstrapDeprecation(metadata)
+  if (!requiresDeprecation && !isCompatibleBootstrapMetadata(metadata, packageName)) {
+    return conflict(packageName, 'resolve conflicting bootstrap deprecation metadata')
+  }
   if (Array.isArray(trust) && trust.length === 0) {
-    return { name: packageName, nextAction: NEXT_CONFIGURE, state: 'pending' }
+    return pendingPackage(packageName, NEXT_CONFIGURE, hasAutomaticLatest)
   }
   if (!isCompatibleTrustConfiguration(trust)) {
     return conflict(
@@ -182,13 +193,24 @@ async function inspectPublishedPlaceholder(
       'resolve conflicting trusted publisher without revoking it automatically',
     )
   }
-  if (needsBootstrapDeprecation(metadata)) {
-    return { name: packageName, nextAction: NEXT_FINALIZE, state: 'pending' }
+  if (requiresDeprecation) {
+    return pendingPackage(packageName, NEXT_FINALIZE, hasAutomaticLatest)
   }
-  if (!isCompatibleBootstrapMetadata(metadata, packageName)) {
-    return conflict(packageName, 'resolve conflicting bootstrap deprecation metadata')
+  return pendingPackage(packageName, NEXT_REASSERT_MFA, hasAutomaticLatest)
+}
+
+function pendingPackage(
+  packageName: string,
+  continuation: string,
+  hasAutomaticLatest: boolean,
+): BootstrapPackageProgress {
+  const nextAction = hasAutomaticLatest
+    ? AUTOMATIC_LATEST_REPAIR_BY_CONTINUATION.get(continuation)
+    : continuation
+  if (nextAction === undefined) {
+    throw new Error(`${packageName} has an unsupported automatic latest repair action.`)
   }
-  return { name: packageName, nextAction: NEXT_REASSERT_MFA, state: 'pending' }
+  return { name: packageName, nextAction, state: 'pending' }
 }
 
 async function inspectPackage(

--- a/scripts/package-release-bootstrap-registry.ts
+++ b/scripts/package-release-bootstrap-registry.ts
@@ -8,6 +8,7 @@ import {
   isCompatibleBootstrapMetadata,
   isCompatibleBootstrapRecord,
   isCompatibleTrustConfiguration,
+  isJsonObject,
   isPublicAccess,
   PACKAGE_NAMES,
   parseJson,
@@ -119,6 +120,40 @@ export async function verifyPublishedPlaceholder(
   if (!isPublicAccess(access, packageName)) {
     throw new Error(`${packageName} must be publicly visible.`)
   }
+}
+
+export async function removeAutomaticBootstrapLatestTag(
+  projectRoot: string,
+  packageName: string,
+  dependencies: BootstrapDependencies,
+) {
+  const tags = parseJson(
+    await runRequired(dependencies, {
+      args: ['view', packageName, 'dist-tags', '--json'],
+      command: 'npm',
+      cwd: projectRoot,
+    }),
+    `npm view ${packageName} dist-tags`,
+  )
+  if (!isJsonObject(tags)) {
+    throw new Error(`${packageName} dist-tags metadata is incompatible.`)
+  }
+  if (tags.latest !== BOOTSTRAP_VERSION) {
+    if (hasCompatibleTags(tags)) return
+    throw new Error(`${packageName} has conflicting bootstrap dist-tags.`)
+  }
+  const tagsWithoutAutomaticLatest = Object.fromEntries(
+    Object.entries(tags).filter(([tag]) => tag !== 'latest'),
+  )
+  if (!hasCompatibleTags(tagsWithoutAutomaticLatest)) {
+    throw new Error(`${packageName} has conflicting bootstrap dist-tags.`)
+  }
+  dependencies.writeLine(`[dist-tag] ${packageName} remove automatic latest`)
+  await runMutation(dependencies, {
+    args: ['dist-tag', 'rm', packageName, 'latest'],
+    command: 'npm',
+    cwd: projectRoot,
+  })
 }
 
 async function createTrust(

--- a/scripts/package-release-bootstrap-types.ts
+++ b/scripts/package-release-bootstrap-types.ts
@@ -70,3 +70,21 @@ export const NEXT_PUBLISH = 'publish bootstrap placeholder'
 export const NEXT_CONFIGURE = 'configure trusted publisher and finalize bootstrap'
 export const NEXT_FINALIZE = 'finalize bootstrap security settings'
 export const NEXT_REASSERT_MFA = 'reassert unverifiable package MFA setting'
+export const NEXT_REMOVE_LATEST_AND_CONFIGURE =
+  'remove automatic bootstrap latest tag, then configure trusted publisher'
+export const NEXT_REMOVE_LATEST_AND_FINALIZE =
+  'remove automatic bootstrap latest tag, then finalize security settings'
+export const NEXT_REMOVE_LATEST_AND_REASSERT_MFA =
+  'remove automatic bootstrap latest tag, then reassert package MFA'
+
+export const AUTOMATIC_LATEST_REPAIR_BY_CONTINUATION = new Map([
+  [NEXT_CONFIGURE, NEXT_REMOVE_LATEST_AND_CONFIGURE],
+  [NEXT_FINALIZE, NEXT_REMOVE_LATEST_AND_FINALIZE],
+  [NEXT_REASSERT_MFA, NEXT_REMOVE_LATEST_AND_REASSERT_MFA],
+])
+
+export const CONTINUATION_BY_AUTOMATIC_LATEST_REPAIR = new Map([
+  [NEXT_REMOVE_LATEST_AND_CONFIGURE, NEXT_CONFIGURE],
+  [NEXT_REMOVE_LATEST_AND_FINALIZE, NEXT_FINALIZE],
+  [NEXT_REMOVE_LATEST_AND_REASSERT_MFA, NEXT_REASSERT_MFA],
+])


### PR DESCRIPTION
## Summary
- accept npm-normalized one-file bootstrap metadata while rejecting contradictory evidence
- repair npm's automatic bootstrap `latest` tag without losing trust/deprecation continuation
- reassert package MFA before any tag mutation

## Validation
- `pnpm check`
- 51 package bootstrap unit tests
- independent read-only review: no remaining P0-P3 findings

This hotfix unblocks the one-time Trusted Publishing namespace bootstrap after the first live npm publish exposed registry normalization behavior.