### PR TITLE
fix(release): authenticate trust reads interactively

### DIFF
--- a/scripts/__tests__/package-release-bootstrap-automatic-latest.unit.test.ts
+++ b/scripts/__tests__/package-release-bootstrap-automatic-latest.unit.test.ts
@@ -48,5 +48,12 @@ describe('package release namespace bootstrap automatic latest handling', () => 
     expect(requests.filter((request) => request.mutates).map(commandKey)).toEqual(
       PACKAGE_NAMES.map((name) => `npm access set mfa=publish ${name}`),
     )
+    expect(
+      requests
+        .filter((request) => commandKey(request).startsWith('npm trust list'))
+        .every(
+          (request) => request.interactive === true && request.captureOutput === true,
+        ),
+    ).toBe(true)
   })
 })

--- a/scripts/__tests__/package-release-bootstrap-preflight.unit.test.ts
+++ b/scripts/__tests__/package-release-bootstrap-preflight.unit.test.ts
@@ -226,4 +226,28 @@ describe('package release namespace bootstrap preflight', () => {
     expect(requests.filter((request) => request.mutates)).toEqual([])
   })
 
+  it('sanitizes npm browser authentication URLs from command failures', async () => {
+    const authId = 'browser-auth-secret'
+    const overrides = new Map<string, BootstrapCommandResult>([
+      [
+        'npm whoami',
+        {
+          exitCode: 1,
+          stderr: [
+            `https://www.npmjs.com/auth/cli/${authId}`,
+            `https://registry.npmjs.org/-/v1/done?authId=${authId}`,
+          ].join('\n'),
+          stdout: '',
+        },
+      ],
+    ])
+    const { dependencies } = createDependencies(overrides)
+
+    await expect(
+      runPackageReleaseBootstrap(
+        { args: ['--execute'], projectRoot: '/workspace/OpenWaggle' },
+        dependencies,
+      ),
+    ).rejects.not.toThrow(authId)
+  })
 })

--- a/scripts/__tests__/package-release-bootstrap-trust.unit.test.ts
+++ b/scripts/__tests__/package-release-bootstrap-trust.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { parseTrustListOutput } from '../package-release-bootstrap-trust'
+import { compatibleTrustConfiguration } from './package-release-bootstrap-test-helpers'
+
+describe('package release bootstrap trust output', () => {
+  it('ignores the npm authentication handoff and returns the trust configuration', () => {
+    const trust = compatibleTrustConfiguration()
+    const output = [
+      JSON.stringify({
+        title: 'Authenticate your account at',
+        url: 'https://www.npmjs.com/auth/cli/redacted',
+      }),
+      JSON.stringify(trust, null, 2),
+    ].join('\r\n')
+
+    expect(parseTrustListOutput(output)).toEqual(trust)
+  })
+
+  it('returns an empty list when the authenticated package has no trust configuration', () => {
+    const output = JSON.stringify({
+      title: 'Authenticate your account at',
+      url: 'https://www.npmjs.com/auth/cli/redacted',
+    })
+
+    expect(parseTrustListOutput(output)).toEqual([])
+  })
+
+  it('preserves multiple configurations so compatibility validation fails closed', () => {
+    const first = compatibleTrustConfiguration()
+    const second = { ...first, repository: 'untrusted/repository' }
+
+    expect(parseTrustListOutput(`${JSON.stringify(first)}\n${JSON.stringify(second)}`)).toEqual([
+      first,
+      second,
+    ])
+  })
+})

--- a/scripts/package-release-bootstrap-adapters.ts
+++ b/scripts/package-release-bootstrap-adapters.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { spawn as spawnPseudoterminal } from 'node-pty'
 import { isCredentialEnvironmentKey } from './package-release-bootstrap-commands'
 import type {
   BootstrapCommandRequest,
@@ -12,6 +13,8 @@ import type {
 } from './package-release-bootstrap-types'
 
 const COMMAND_FAILURE_EXIT_CODE = 1
+const DEFAULT_TERMINAL_COLUMNS = 80
+const DEFAULT_TERMINAL_ROWS = 24
 const PRIVATE_FILE_MODE = 0o600
 export const BOOTSTRAP_SECURITY_RECOVERY_TIMEOUT_MS = 120_000
 const BOOTSTRAP_SIGNALS = ['SIGINT', 'SIGTERM'] as const
@@ -129,10 +132,62 @@ function childEnvironment(source: NodeJS.ProcessEnv) {
   return environment
 }
 
+function pseudoterminalEnvironment(source: NodeJS.ProcessEnv) {
+  return {
+    ...Object.fromEntries(
+      Object.entries(childEnvironment(source)).filter(
+        (entry): entry is [string, string] => entry[1] !== undefined,
+      ),
+    ),
+    NPM_CONFIG_PROGRESS: 'false',
+  }
+}
+
+function executePseudoterminalCommand(
+  request: BootstrapCommandRequest,
+  interruptions: BootstrapInterruptionCoordinator,
+): Promise<BootstrapCommandResult> {
+  return new Promise((resolve) => {
+    const child = spawnPseudoterminal(request.command, [...request.args], {
+      cols: process.stdout.columns ?? DEFAULT_TERMINAL_COLUMNS,
+      cwd: request.cwd,
+      env: pseudoterminalEnvironment(process.env),
+      name: 'xterm-color',
+      rows: process.stdout.rows ?? DEFAULT_TERMINAL_ROWS,
+    })
+    const untrackChild = interruptions.trackChild({
+      kill: (signal) => {
+        child.kill(signal)
+        return true
+      },
+    })
+    const stdinWasFlowing = process.stdin.readableFlowing === true
+    let output = ''
+
+    const forwardInput = (chunk: Buffer | string) => child.write(String(chunk))
+    process.stdin.on('data', forwardInput)
+    process.stdin.resume()
+
+    child.onData((chunk) => {
+      output += chunk
+      process.stdout.write(chunk)
+    })
+    child.onExit(({ exitCode }) => {
+      process.stdin.off('data', forwardInput)
+      if (!stdinWasFlowing) process.stdin.pause()
+      untrackChild()
+      resolve({ exitCode, stderr: '', stdout: output })
+    })
+  })
+}
+
 function executeCommand(
   request: BootstrapCommandRequest,
   interruptions: BootstrapInterruptionCoordinator,
 ): Promise<BootstrapCommandResult> {
+  if (request.interactive === true && request.captureOutput === true) {
+    return executePseudoterminalCommand(request, interruptions)
+  }
   return new Promise((resolve) => {
     const child = spawn(request.command, request.args, {
       cwd: request.cwd,

--- a/scripts/package-release-bootstrap-commands.ts
+++ b/scripts/package-release-bootstrap-commands.ts
@@ -27,6 +27,11 @@ export function redactBootstrapDiagnostic(value: string) {
     .replace(/(gh[opsu]_[A-Za-z0-9_]{20,})/gu, '[redacted]')
     .replace(/(github_pat_[A-Za-z0-9_]{20,})/gu, '[redacted]')
     .replace(/(Bearer\s+)[^\s]+/giu, '$1[redacted]')
+    .replace(/(https:\/\/www\.npmjs\.com\/auth\/cli\/)[^\s"']+/giu, '$1[redacted]')
+    .replace(
+      /(https:\/\/registry\.npmjs\.org\/-\/v1\/done\?authId=)[^\s"']+/giu,
+      '$1[redacted]',
+    )
     .trim()
 }
 

--- a/scripts/package-release-bootstrap-preflight.ts
+++ b/scripts/package-release-bootstrap-preflight.ts
@@ -20,6 +20,7 @@ import {
   parseJsonObject,
   type JsonObject,
 } from './package-release-bootstrap-model'
+import { readTrustConfiguration } from './package-release-bootstrap-trust'
 import {
   NEXT_CONFIGURE,
   NEXT_FINALIZE,
@@ -163,13 +164,7 @@ async function inspectPublishedPlaceholder(
   if (!isPublicAccess(access, packageName)) {
     return conflict(packageName, 'make the existing bootstrap package public')
   }
-  const trustOutput = await runRequired(dependencies, {
-    args: ['trust', 'list', packageName, '--json'],
-    command: 'npm',
-    cwd: projectRoot,
-  })
-  const trust =
-    trustOutput.length === 0 ? [] : parseJson(trustOutput, `npm trust list ${packageName}`)
+  const trust = await readTrustConfiguration(projectRoot, packageName, dependencies)
   const requiresDeprecation = needsBootstrapDeprecation(metadata)
   if (!requiresDeprecation && !isCompatibleBootstrapMetadata(metadata, packageName)) {
     return conflict(packageName, 'resolve conflicting bootstrap deprecation metadata')

--- a/scripts/package-release-bootstrap-registry.ts
+++ b/scripts/package-release-bootstrap-registry.ts
@@ -14,6 +14,7 @@ import {
   parseJsonObject,
 } from './package-release-bootstrap-model'
 import type { BootstrapDependencies } from './package-release-bootstrap-types'
+import { readTrustConfiguration } from './package-release-bootstrap-trust'
 
 const JSON_INDENT_SPACES = 2
 
@@ -153,14 +154,7 @@ async function verifyTrust(
   packageName: string,
   dependencies: BootstrapDependencies,
 ) {
-  const trust = parseJson(
-    await runRequired(dependencies, {
-      args: ['trust', 'list', packageName, '--json'],
-      command: 'npm',
-      cwd: projectRoot,
-    }),
-    `npm trust list ${packageName}`,
-  )
+  const trust = await readTrustConfiguration(projectRoot, packageName, dependencies)
   if (!isCompatibleTrustConfiguration(trust)) {
     throw new Error(`${packageName} trusted publisher verification failed.`)
   }

--- a/scripts/package-release-bootstrap-trust.ts
+++ b/scripts/package-release-bootstrap-trust.ts
@@ -1,0 +1,76 @@
+import { stripVTControlCharacters } from 'node:util'
+import { runRequired } from './package-release-bootstrap-commands'
+import { isJsonObject, type JsonObject } from './package-release-bootstrap-model'
+import type { BootstrapDependencies } from './package-release-bootstrap-types'
+
+function jsonObjects(value: string) {
+  const normalized = stripVTControlCharacters(value)
+  const documents: JsonObject[] = []
+  for (let start = 0; start < normalized.length; start += 1) {
+    if (normalized[start] !== '{') continue
+    let depth = 0
+    let escaped = false
+    let quoted = false
+    for (let end = start; end < normalized.length; end += 1) {
+      const character = normalized[end]
+      if (quoted) {
+        if (escaped) {
+          escaped = false
+          continue
+        }
+        if (character === '\\') {
+          escaped = true
+          continue
+        }
+        if (character === '"') quoted = false
+        continue
+      }
+      if (character === '"') {
+        quoted = true
+        continue
+      }
+      if (character === '{') {
+        depth += 1
+        continue
+      }
+      if (character !== '}') continue
+      depth -= 1
+      if (depth !== 0) continue
+      try {
+        const parsed: unknown = JSON.parse(normalized.slice(start, end + 1))
+        if (isJsonObject(parsed)) documents.push(parsed)
+        start = end
+      } catch {
+        // Non-JSON terminal output can contain braces; keep scanning for the next object.
+      }
+      break
+    }
+  }
+  return documents
+}
+
+function isAuthenticationHandoff(value: JsonObject) {
+  return value.title === 'Authenticate your account at' && typeof value.url === 'string'
+}
+
+export function parseTrustListOutput(value: string): unknown {
+  const configurations = jsonObjects(value).filter((item) => !isAuthenticationHandoff(item))
+  if (configurations.length === 0) return []
+  if (configurations.length === 1) return configurations[0]
+  return configurations
+}
+
+export async function readTrustConfiguration(
+  projectRoot: string,
+  packageName: string,
+  dependencies: BootstrapDependencies,
+) {
+  const output = await runRequired(dependencies, {
+    args: ['trust', 'list', packageName, '--json'],
+    captureOutput: true,
+    command: 'npm',
+    cwd: projectRoot,
+    interactive: true,
+  })
+  return parseTrustListOutput(output)
+}

--- a/scripts/package-release-bootstrap-types.ts
+++ b/scripts/package-release-bootstrap-types.ts
@@ -1,5 +1,6 @@
 export interface BootstrapCommandRequest {
   readonly args: readonly string[]
+  readonly captureOutput?: boolean
   readonly command: string
   readonly cwd?: string
   readonly input?: string


### PR DESCRIPTION
## Summary
- run npm trust reads through a pseudo-terminal so npm browser authentication can complete
- parse authenticated trust output while filtering npm auth handoff metadata
- redact one-time npm auth URLs from diagnostics

## Validation
- pnpm check
- real npm trust-list browser authentication returned PARSED_TRUST=[]
- independent read-only review: no findings