### PR TITLE
fix(ci): attribute merge paths to first parent

### DIFF
--- a/scripts/__tests__/check-conventional-commit-merges.unit.test.ts
+++ b/scripts/__tests__/check-conventional-commit-merges.unit.test.ts
@@ -1,0 +1,183 @@
+import { execFile as execFileCallback } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+import { validateConventionalCommits } from '../check-conventional-commits'
+
+const execFile = promisify(execFileCallback)
+const POLICY_SCRIPT_PATH = 'scripts/check-conventional-commits.ts'
+const GIT_IDENTITY = [
+  '-c',
+  'user.name=OpenWaggle Tests',
+  '-c',
+  'user.email=tests@openwaggle.ai',
+] as const
+
+async function git(cwd: string, args: readonly string[]) {
+  const { stdout } = await execFile('git', args, { cwd })
+  return stdout.trim()
+}
+
+async function writeAndCommit(
+  cwd: string,
+  filePath: string,
+  contents: string,
+  message: string,
+) {
+  const absolutePath = path.join(cwd, filePath)
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true })
+  await fs.writeFile(absolutePath, contents, 'utf8')
+  await git(cwd, ['add', filePath])
+  await git(cwd, [...GIT_IDENTITY, 'commit', '-m', message])
+  return git(cwd, ['rev-parse', 'HEAD'])
+}
+
+async function createRepository() {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-commit-policy-'))
+  await git(cwd, ['init', '-b', 'main'])
+  await writeAndCommit(cwd, 'history.txt', 'history\n', 'historical commit')
+  const baseline = await writeAndCommit(
+    cwd,
+    POLICY_SCRIPT_PATH,
+    'current policy marker\n',
+    'ci: introduce commit policy',
+  )
+  return { baseline, cwd }
+}
+
+async function merge(cwd: string, branch: string, message: string) {
+  await git(cwd, [...GIT_IDENTITY, 'merge', '--no-ff', branch, '-m', message])
+  return git(cwd, ['rev-parse', 'HEAD'])
+}
+
+describe('Conventional Commit merge attribution', () => {
+  it('attributes update-branch merges against their first parent', async () => {
+    const { baseline, cwd } = await createRepository()
+    try {
+      await git(cwd, ['checkout', '-b', 'release-please'])
+      await writeAndCommit(
+        cwd,
+        'packages/extension-sdk/package.json',
+        '{"version":"0.1.0"}\n',
+        'chore(release): release packages',
+      )
+      await git(cwd, ['checkout', 'main'])
+      await writeAndCommit(
+        cwd,
+        'scripts/release-helper.ts',
+        'export {}\n',
+        'fix(release): harden release helper',
+      )
+      await git(cwd, ['checkout', 'release-please'])
+      const updateMerge = await merge(cwd, 'main', "Merge branch 'main' into release-please")
+
+      const result = await validateConventionalCommits({ baseline, cwd, to: updateMerge })
+
+      expect(result.violations).toEqual([])
+      expect(result.commits.find((item) => item.hash === updateMerge)?.changedPaths).toEqual([
+        'scripts/release-helper.ts',
+      ])
+    } finally {
+      await fs.rm(cwd, { force: true, recursive: true })
+    }
+  })
+
+  it('still rejects package changes merged into the first-parent branch', async () => {
+    const { baseline, cwd } = await createRepository()
+    try {
+      await git(cwd, ['checkout', '-b', 'package-change'])
+      await writeAndCommit(
+        cwd,
+        'packages/extension-sdk/package.json',
+        '{"version":"0.1.0"}\n',
+        'fix(extension-sdk): update package metadata',
+      )
+      await git(cwd, ['checkout', 'main'])
+      const packageMerge = await merge(
+        cwd,
+        'package-change',
+        'Merge pull request #123 from OpenWaggle/package-change',
+      )
+
+      const result = await validateConventionalCommits({ baseline, cwd, to: packageMerge })
+
+      expect(result.violations).toContain(
+        `${packageMerge}: "Merge pull request #123 from OpenWaggle/package-change" affects a publishable package and must carry explicit Conventional Commit release intent.`,
+      )
+    } finally {
+      await fs.rm(cwd, { force: true, recursive: true })
+    }
+  })
+
+  it('retains a package source path when a merge moves it outside packages', async () => {
+    const { baseline, cwd } = await createRepository()
+    try {
+      await writeAndCommit(
+        cwd,
+        'packages/extension-sdk/api.ts',
+        'export {}\n',
+        'feat(extension-sdk): add public api',
+      )
+      await git(cwd, ['checkout', '-b', 'package-move'])
+      await fs.mkdir(path.join(cwd, 'src'), { recursive: true })
+      await fs.rename(
+        path.join(cwd, 'packages/extension-sdk/api.ts'),
+        path.join(cwd, 'src/api.ts'),
+      )
+      await git(cwd, ['add', '--all'])
+      await git(cwd, [...GIT_IDENTITY, 'commit', '-m', 'refactor: move package api'])
+      await git(cwd, ['checkout', 'main'])
+      const packageMerge = await merge(
+        cwd,
+        'package-move',
+        'Merge pull request #124 from OpenWaggle/package-move',
+      )
+
+      const result = await validateConventionalCommits({ baseline, cwd, to: packageMerge })
+      const mergeCommit = result.commits.find((item) => item.hash === packageMerge)
+
+      expect(mergeCommit?.changedPaths).toEqual([
+        'packages/extension-sdk/api.ts',
+        'src/api.ts',
+      ])
+      expect(result.violations).toContain(
+        `${packageMerge}: "Merge pull request #124 from OpenWaggle/package-move" affects a publishable package and must carry explicit Conventional Commit release intent.`,
+      )
+    } finally {
+      await fs.rm(cwd, { force: true, recursive: true })
+    }
+  })
+
+  it('captures single-parent package paths and excludes the policy root baseline', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-commit-policy-'))
+    try {
+      await git(cwd, ['init', '-b', 'main'])
+      const baseline = await writeAndCommit(
+        cwd,
+        POLICY_SCRIPT_PATH,
+        'current policy marker\n',
+        'historical root without conventional intent',
+      )
+      const packageCommit = await writeAndCommit(
+        cwd,
+        'packages/extension-sdk/api.ts',
+        'export {}\n',
+        'fix(extension-sdk): expose package api',
+      )
+
+      const result = await validateConventionalCommits({ cwd, to: packageCommit })
+
+      expect(result.effectiveFrom).toBe(baseline)
+      expect(result.commits).toHaveLength(1)
+      expect(result.commits[0]).toMatchObject({
+        changedPaths: ['packages/extension-sdk/api.ts'],
+        hash: packageCommit,
+      })
+      expect(result.violations).toEqual([])
+    } finally {
+      await fs.rm(cwd, { force: true, recursive: true })
+    }
+  })
+})

--- a/scripts/__tests__/check-conventional-commits.unit.test.ts
+++ b/scripts/__tests__/check-conventional-commits.unit.test.ts
@@ -267,4 +267,5 @@ describe('Conventional Commit policy', () => {
       await fs.rm(cwd, { force: true, recursive: true })
     }
   })
+
 })

--- a/scripts/check-conventional-commits.ts
+++ b/scripts/check-conventional-commits.ts
@@ -150,17 +150,32 @@ async function readCommitSubjects(cwd: string, from: string, to: string) {
     }
 
     const normalizedHash = hash.trim()
+    const parentHashes = parents.trim().split(' ').filter((parentHash) => parentHash.length > 0)
+    const firstParent = parentHashes[0]
+    const changedPathsArgs =
+      parentHashes.length > 1 && firstParent !== undefined
+        ? ['diff', '--no-renames', '--name-only', '-z', firstParent, normalizedHash]
+        : [
+            'diff-tree',
+            '--no-commit-id',
+            '--no-renames',
+            '--name-only',
+            '--root',
+            '-r',
+            '-z',
+            normalizedHash,
+          ]
     const { stdout: changedPathsOutput } = await execFile(
       'git',
-      ['diff-tree', '--no-commit-id', '--name-only', '-r', '-m', normalizedHash],
+      changedPathsArgs,
       { cwd, maxBuffer: GIT_LOG_MAX_BUFFER_BYTES },
     )
 
     commits.push({
       body,
-      changedPaths: [...new Set(changedPathsOutput.split('\n').filter((entry) => entry.length > 0))],
+      changedPaths: [...new Set(changedPathsOutput.split('\0').filter((entry) => entry.length > 0))],
       hash: normalizedHash,
-      parentHashes: parents.trim().split(' ').filter((parentHash) => parentHash.length > 0),
+      parentHashes,
       subject,
     })
   }


### PR DESCRIPTION
## Summary
- attribute generated merge changes against the first parent instead of unioning all parent diffs
- preserve package source paths across renames with no-rename, NUL-delimited parsing
- cover update-branch, package-merge, rename, root-baseline, and single-parent topologies

## Validation
- pnpm check
- exact release head c531655 conventional policy passes
- independent review: all findings fixed, no residual P0-P3