### PR TITLE
chore(release): reconcile protected release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,67 +12,72 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   version:
-    name: Determine Version
-    # Skip version-bump commits to avoid infinite loop
+    name: Prepare Protected Version
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     outputs:
-      new_version: ${{ steps.bump.outputs.new_version }}
-      new_tag: ${{ steps.bump.outputs.new_tag }}
-      should_release: ${{ steps.bump.outputs.should_release }}
+      new_version: ${{ steps.release.outputs.new_version }}
+      new_tag: ${{ steps.release.outputs.new_tag }}
+      should_release: ${{ steps.release.outputs.should_release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Determine bump from conventional commits
         id: bump
         run: |
-          # Find the last version tag (or use initial commit if none)
-          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            RANGE="HEAD"
-          else
+          set -euo pipefail
+          if LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
             RANGE="${LAST_TAG}..HEAD"
+          else
+            LAST_TAG=""
+            RANGE="HEAD"
           fi
 
           echo "Last tag: ${LAST_TAG:-none}"
           echo "Commit range: ${RANGE}"
-
-          # Read commit subjects since last tag
-          COMMITS=$(git log --format='%s' ${RANGE} 2>/dev/null || git log --format='%s')
-
-          # Determine bump type from conventional commit prefixes
+          COMMITS=$(git log --format='%s' "$RANGE")
+          BODIES=$(git log --format='%b' "$RANGE")
           HAS_BREAKING=false
           HAS_FEAT=false
           HAS_FIX=false
 
-          while IFS= read -r msg; do
-            # Skip empty lines
-            [ -z "$msg" ] && continue
-            # Check for breaking change marker
-            if echo "$msg" | grep -qiE '^[a-z]+(\(.+\))?!:'; then
+          while IFS= read -r message; do
+            [ -z "$message" ] && continue
+            if grep -qiE '^[a-z]+(\(.+\))?!:' <<<"$message"; then
               HAS_BREAKING=true
             fi
-            if echo "$msg" | grep -qE '^feat(\(.+\))?:'; then
+            if grep -qE '^feat(\(.+\))?:' <<<"$message"; then
               HAS_FEAT=true
             fi
-            if echo "$msg" | grep -qE '^fix(\(.+\))?:'; then
+            if grep -qE '^fix(\(.+\))?:' <<<"$message"; then
               HAS_FIX=true
             fi
-          done <<< "$COMMITS"
+          done <<<"$COMMITS"
 
-          # Also check commit bodies for BREAKING CHANGE
-          BODIES=$(git log --format='%b' ${RANGE} 2>/dev/null || git log --format='%b')
-          if echo "$BODIES" | grep -q 'BREAKING CHANGE'; then
+          if grep -q 'BREAKING CHANGE' <<<"$BODIES"; then
             HAS_BREAKING=true
           fi
 
-          # Determine bump type
           if [ "$HAS_BREAKING" = true ]; then
             BUMP="major"
           elif [ "$HAS_FEAT" = true ]; then
@@ -80,25 +85,19 @@ jobs:
           elif [ "$HAS_FIX" = true ]; then
             BUMP="patch"
           else
-            echo "No feat: or fix: commits since last release — skipping"
+            echo "No feat: or fix: commits since last release; skipping."
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Get current version from package.json
-          CURRENT=$(node -e "console.log(require('./package.json').version)")
-          echo "Current version: ${CURRENT}"
-
-          # Extract base version and prerelease counter
-          # Format: X.Y.Z-alpha.N or X.Y.Z-beta.N → bump N+1
-          # Format: X.Y.Z (no prerelease) → use standard semver bumps
-          if echo "$CURRENT" | grep -qE 'alpha|beta'; then
+          CURRENT=$(node -p "require('./package.json').version")
+          if grep -qE 'alpha|beta' <<<"$CURRENT"; then
             BASE_VERSION="${CURRENT%%-*}"
-            PRERELEASE_TAG=$(echo "$CURRENT" | sed 's/.*-\(alpha\|beta\)\..*/\1/')
-            PRERELEASE_NUM=$(echo "$CURRENT" | sed 's/.*\(alpha\|beta\)\.\([0-9]*\).*/\2/')
+            PRERELEASE_TAG=$(sed 's/.*-\(alpha\|beta\)\..*/\1/' <<<"$CURRENT")
+            PRERELEASE_NUM=$(sed 's/.*\(alpha\|beta\)\.\([0-9]*\).*/\2/' <<<"$CURRENT")
             NEW_VERSION="${BASE_VERSION}-${PRERELEASE_TAG}.$((PRERELEASE_NUM + 1))"
           else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT"
             case "$BUMP" in
               major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
               minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
@@ -106,32 +105,230 @@ jobs:
             esac
             NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           fi
-          echo "New version: ${NEW_VERSION}"
 
           echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "new_tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           echo "should_release=true" >> "$GITHUB_OUTPUT"
 
-      - name: Bump package.json and push tag
+      - name: Create, validate, and merge release PR
         if: steps.bump.outputs.should_release == 'true'
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.bump.outputs.new_version }}
         run: |
-          VERSION="${{ steps.bump.outputs.new_version }}"
-          TAG="${{ steps.bump.outputs.new_tag }}"
+          set -euo pipefail
+          RELEASE_BRANCH="app-release-v${VERSION}"
+          TAG="v${VERSION}"
 
-          # Bump version in package.json (no npm dependencies needed)
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '${VERSION}';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
+          verify_version_only_tree() {
+            local base_ref="$1"
+            local candidate_ref="$2"
+            test "$(git diff --name-only "${base_ref}...${candidate_ref}")" = "package.json"
+            git show "${base_ref}:package.json" > "$RUNNER_TEMP/base-package.json"
+            git show "${candidate_ref}:package.json" > "$RUNNER_TEMP/candidate-package.json"
+            pnpm exec tsx scripts/app-release-state.ts expected-manifest \
+              --base "$RUNNER_TEMP/base-package.json" \
+              --output "$RUNNER_TEMP/expected-package.json" \
+              --version "$VERSION"
+            cmp "$RUNNER_TEMP/expected-package.json" "$RUNNER_TEMP/candidate-package.json"
+          }
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "chore(release): v${VERSION}"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin main --follow-tags
+          verify_release_commit() {
+            local commit_sha="$1"
+            [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]]
+            git fetch origin \
+              "+refs/heads/main:refs/remotes/origin/main"
+            git merge-base --is-ancestor "$commit_sha" origin/main
+            test "$(git show -s --format=%s "$commit_sha")" = "chore(release): v${VERSION}"
+            local parent_sha
+            parent_sha=$(git rev-parse "${commit_sha}^")
+            verify_version_only_tree "$parent_sha" "$commit_sha"
+          }
+
+          write_release_outputs() {
+            echo "new_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "new_tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          }
+
+          if git ls-remote --exit-code origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+            TAG_COMMIT=$(git rev-list -n 1 "$TAG")
+            verify_release_commit "$TAG_COMMIT"
+            write_release_outputs
+            exit 0
+          fi
+
+          ALL_PRS=$(gh pr list --state all --head "$RELEASE_BRANCH" --limit 100 \
+            --json baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,mergeCommit,number,state,title,url)
+          PRS=$(pnpm exec tsx scripts/app-release-state.ts filter-prs \
+            --branch "$RELEASE_BRANCH" \
+            --owner "$GITHUB_REPOSITORY_OWNER" \
+            --repository "${GITHUB_REPOSITORY#*/}" \
+            <<<"$ALL_PRS")
+          PR_COUNT=$(jq -er 'length' <<<"$PRS")
+          if [ "$PR_COUNT" -gt 1 ]; then
+            echo "Multiple release PRs use ${RELEASE_BRANCH}."
+            exit 1
+          fi
+
+          PR_URL=""
+          PR_STATE=""
+          MERGE_SHA=""
+          if [ "$PR_COUNT" -eq 1 ]; then
+            PR_URL=$(jq -er '.[0].url' <<<"$PRS")
+            PR_STATE=$(jq -er '.[0].state' <<<"$PRS")
+            test "$(jq -er '.[0].baseRefName' <<<"$PRS")" = "main"
+            test "$(jq -er '.[0].headRefName' <<<"$PRS")" = "$RELEASE_BRANCH"
+            test "$(jq -er '.[0].title' <<<"$PRS")" = "chore(release): v${VERSION}"
+            if [ "$PR_STATE" = "MERGED" ]; then
+              MERGE_SHA=$(jq -er '.[0].mergeCommit.oid' <<<"$PRS")
+            elif [ "$PR_STATE" != "OPEN" ]; then
+              echo "Release PR is closed without being merged: ${PR_URL}"
+              exit 1
+            fi
+          fi
+
+          if [ -z "$PR_URL" ]; then
+            if git ls-remote --exit-code origin "refs/heads/${RELEASE_BRANCH}" >/dev/null 2>&1; then
+              git fetch origin "refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+              git switch --detach "origin/${RELEASE_BRANCH}"
+            else
+              pnpm exec tsx scripts/app-release-state.ts expected-manifest \
+                --base package.json \
+                --output package.json \
+                --version "$VERSION"
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git switch -c "$RELEASE_BRANCH"
+              git add package.json
+              git commit -m "chore(release): v${VERSION}"
+              git push origin "$RELEASE_BRANCH"
+            fi
+
+            git fetch origin \
+              "+refs/heads/main:refs/remotes/origin/main" \
+              "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+            verify_version_only_tree "origin/main" "origin/${RELEASE_BRANCH}"
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$RELEASE_BRANCH" \
+              --title "chore(release): v${VERSION}" \
+              --body "Automated desktop app version release. CI must pass for this exact commit before merge.")
+            PR_STATE="OPEN"
+          fi
+
+          if [ "$PR_STATE" = "OPEN" ]; then
+            PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+            for MERGE_ATTEMPT in $(seq 1 3); do
+              PR_DETAILS=$(gh pr view "$PR_URL" \
+                --json baseRefName,headRefName,headRefOid,mergeStateStatus,state,title)
+              test "$(jq -er '.state' <<<"$PR_DETAILS")" = "OPEN"
+              test "$(jq -er '.baseRefName' <<<"$PR_DETAILS")" = "main"
+              test "$(jq -er '.headRefName' <<<"$PR_DETAILS")" = "$RELEASE_BRANCH"
+              test "$(jq -er '.title' <<<"$PR_DETAILS")" = "chore(release): v${VERSION}"
+              HEAD_SHA=$(jq -er '.headRefOid' <<<"$PR_DETAILS")
+              MERGE_STATE=$(jq -er '.mergeStateStatus' <<<"$PR_DETAILS")
+              [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+              if [ "$MERGE_STATE" = "BEHIND" ]; then
+                gh api --method PUT \
+                  "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/update-branch" \
+                  -f "expected_head_sha=${HEAD_SHA}" >/dev/null
+                for UPDATE_ATTEMPT in $(seq 1 30); do
+                  UPDATED_SHA=$(gh pr view "$PR_URL" --json headRefOid --jq '.headRefOid')
+                  if [ "$UPDATED_SHA" != "$HEAD_SHA" ]; then
+                    HEAD_SHA="$UPDATED_SHA"
+                    break
+                  fi
+                  echo "Waiting for release branch update (${UPDATE_ATTEMPT}/30)."
+                  sleep 2
+                done
+                test "$HEAD_SHA" != "$(jq -er '.headRefOid' <<<"$PR_DETAILS")"
+              fi
+
+              git fetch origin \
+                "+refs/heads/main:refs/remotes/origin/main" \
+                "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+              test "$(git rev-parse "origin/${RELEASE_BRANCH}")" = "$HEAD_SHA"
+              verify_version_only_tree "origin/main" "origin/${RELEASE_BRANCH}"
+
+              gh workflow run ci.yml --ref "$RELEASE_BRANCH" -f "head_sha=${HEAD_SHA}"
+              RUN_ID=""
+              for RUN_ATTEMPT in $(seq 1 60); do
+                RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?event=workflow_dispatch&branch=${RELEASE_BRANCH}&per_page=20")
+                if RUN_ID=$(jq -er --arg sha "$HEAD_SHA" \
+                  '.workflow_runs | map(select(.head_sha == $sha)) | first | .id' <<<"$RUNS"); then
+                  break
+                fi
+                echo "Waiting for exact-head CI run (${RUN_ATTEMPT}/60)."
+                sleep 5
+              done
+              test -n "$RUN_ID"
+              gh run watch "$RUN_ID" --exit-status
+
+              if gh pr merge "$PR_URL" \
+                --squash \
+                --delete-branch \
+                --match-head-commit "$HEAD_SHA" \
+                --subject "chore(release): v${VERSION}" \
+                --body ""; then
+                break
+              fi
+              RETRY_STATE=""
+              for STATE_ATTEMPT in $(seq 1 30); do
+                AFTER_MERGE=$(gh pr view "$PR_URL" --json mergeCommit,mergeStateStatus,state)
+                AFTER_STATE=$(jq -er '.state' <<<"$AFTER_MERGE")
+                AFTER_MERGE_STATE=$(jq -er '.mergeStateStatus' <<<"$AFTER_MERGE")
+                RECOVERY_ACTION=$(pnpm exec tsx scripts/app-release-state.ts merge-action \
+                  --state "$AFTER_STATE" \
+                  --merge-state "$AFTER_MERGE_STATE")
+                case "$RECOVERY_ACTION" in
+                  complete)
+                    MERGE_SHA=$(jq -er '.mergeCommit.oid' <<<"$AFTER_MERGE")
+                    RETRY_STATE="MERGED"
+                    break
+                    ;;
+                  retry)
+                    RETRY_STATE="BEHIND"
+                    break
+                    ;;
+                  poll)
+                    echo "Waiting for merge state (${STATE_ATTEMPT}/30): ${AFTER_MERGE_STATE}."
+                    sleep 2
+                    ;;
+                  conflict)
+                    echo "Release PR merge failed in terminal state: ${AFTER_STATE}/${AFTER_MERGE_STATE}."
+                    exit 1
+                    ;;
+                esac
+              done
+              if [ "$RETRY_STATE" = "MERGED" ]; then
+                break
+              fi
+              if [ "$MERGE_ATTEMPT" -eq 3 ] || [ "$RETRY_STATE" != "BEHIND" ]; then
+                echo "Release PR did not merge after strict-base retries."
+                exit 1
+              fi
+            done
+
+            if [ -z "$MERGE_SHA" ]; then
+              MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit,mergedAt \
+                --jq 'select(.mergedAt != null) | .mergeCommit.oid')
+            fi
+          fi
+
+          verify_release_commit "$MERGE_SHA"
+          if git ls-remote --exit-code origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+            test "$(git rev-list -n 1 "$TAG")" = "$MERGE_SHA"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" "$MERGE_SHA" -m "Release ${TAG}"
+            git push origin "refs/tags/${TAG}"
+          fi
+          write_release_outputs
 
   build-macos:
     name: Build macOS
@@ -139,13 +336,13 @@ jobs:
     if: needs.version.outputs.should_release == 'true'
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.version.outputs.new_tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -159,7 +356,7 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-artifacts
           path: |
@@ -174,13 +371,13 @@ jobs:
     if: needs.version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.version.outputs.new_tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -192,7 +389,7 @@ jobs:
       - name: Build Linux AppImage
         run: pnpm exec electron-builder --linux --publish never
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-artifacts
           path: |
@@ -206,13 +403,13 @@ jobs:
     if: needs.version.outputs.should_release == 'true'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.version.outputs.new_tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -224,7 +421,7 @@ jobs:
       - name: Build Windows NSIS installer
         run: pnpm exec electron-builder --win --publish never
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-artifacts
           path: |
@@ -251,11 +448,11 @@ jobs:
             artifact_name: windows-artifacts
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.version.outputs.new_tag }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ runner.temp }}/release/${{ matrix.platform }}
@@ -352,12 +549,14 @@ jobs:
     needs: [version, verify-installers]
     if: needs.version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.version.outputs.new_tag }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -368,7 +567,7 @@ jobs:
           cd release && sha256sum * > SHA256SUMS.txt
 
       - name: Create draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.version.outputs.new_tag }}
           name: ${{ needs.version.outputs.new_tag }}

--- a/docs/agents/release.md
+++ b/docs/agents/release.md
@@ -10,7 +10,9 @@ Release automation is GitHub-based:
 
 - CI runs typecheck, lint, and tests on PRs and pushes to `main`.
 - Release workflow derives version bumps from Conventional Commit-style release-eligible commits.
-- Release workflow updates `package.json`, creates a tag, builds platform artifacts, publishes a GitHub Release, and attaches checksums.
+- Release workflow opens a generated version PR, dispatches and waits for exact-head CI, and merges through normal `main` protection. Strict-base drift updates the branch and repeats CI before another merge attempt. The same run verifies the resulting protected merge commit, creates only its tag, then builds platform artifacts, publishes a GitHub Release, and attaches checksums. Reruns resume only compatible existing branch, PR, merge, and tag state; conflicting durable state fails closed.
+
+The `0.3.0-alpha.44` recovery is intentionally exceptional: an earlier blocked direct push left that tag pointing to an unreachable commit. The reconciliation commit records `0.3.0-alpha.44` on `main` with a non-version `chore(release):` subject so no tag or build runs. Preserve the orphan tag; the next generated version PR must advance to `0.3.0-alpha.45`.
 
 Published artifacts are currently unsigned. macOS notarization and Windows signing are release/distribution trust work, not routine implementation tasks.
 

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -10,7 +10,7 @@ Husky is configured with a `pre-push` hook that runs only when pushing to `main`
 
 ## CI/CD
 
-Every push to `main` and every PR runs CI for typechecking, linting, and tests. The current release workflow is still Conventional Commit derived: when release-eligible commits land on `main`, CI determines the version bump, updates `package.json`, creates a tag, builds platform artifacts, and publishes a GitHub Release with checksums.
+Every push to `main` and every PR runs CI for typechecking, linting, and tests. The current release workflow is still Conventional Commit derived: when release-eligible commits land on `main`, CI determines the version bump and opens a generated version PR. The workflow dispatches CI for that PR's exact head, waits for all required checks, and squash-merges through normal `main` protection. If `main` advances, it updates the release branch and repeats exact-head CI before retrying the merge. The same run verifies the protected merge SHA and version, pushes only its tag, builds platform artifacts, and publishes a GitHub Release with checksums. Reruns adopt compatible existing release branches, PRs, protected merge commits, and tags while rejecting conflicting state.
 
 The workflow currently publishes unsigned platform artifacts. Public distribution still depends on platform trust work such as macOS notarization and Windows code signing.
 
@@ -25,6 +25,10 @@ OpenWaggle uses semver with prerelease stages. The current release train is `0.3
 | Stable | `0.3.0` | `fix:` increments patch, `feat:` increments minor, breaking changes increment major. |
 
 To transition stages, manually set the version in `package.json` and commit as `chore(release): <message>`.
+
+### Protected release recovery
+
+The failed `0.3.0-alpha.44` direct-push attempt created a remote tag whose commit never reached protected `main`. Recovery intentionally sets the root version on `main` to `0.3.0-alpha.44` in a `chore(release):` reconciliation commit. That subject skips both release-PR generation and tag publication. The existing orphan tag is preserved for auditability; the next release-eligible change increments the reconciled root version and publishes `0.3.0-alpha.45` from a version PR that passed exact-head CI. Do not delete, move, or reuse the orphan tag.
 
 ## Release Notes
 
@@ -150,7 +154,7 @@ Package publishing should follow the `ts-match` release model:
 - Publish `extension-sdk` and `waggle-core` before `extension-react` and `pi-waggle`, respectively, and verify each base version is resolvable before publishing its dependent.
 - The release job runs on Node 24 with pinned npm `11.18.0` until that pin is deliberately updated. Do not install `npm@latest` during a release.
 - The protected GitHub `npm` environment has no npm secrets or required reviewers, accepts deployments only from `main`, and prevents concurrent package release runs.
-- The additive `main` ruleset requires pull requests and green CI, allows only squash and rebase, blocks force pushes and deletion, and retains an administrator emergency bypass. Repository settings also disable merge commits so GitHub cannot synthesize a package-changing merge subject that passes PR checks but fails the commit policy on `main`. Release Please-created branches receive automatically dispatched CI through `workflow_dispatch`, avoiding a PAT or GitHub App key.
+- The additive `main` ruleset requires pull requests and green CI, allows only squash and rebase, blocks force pushes and deletion, and retains only an administrator emergency bypass. The app release workflow creates a version PR, dispatches CI for its exact head, waits for that run, and merges through the normal ruleset before tagging the protected commit. Repository settings also disable merge commits so GitHub cannot synthesize a package-changing merge subject that passes PR checks but fails the commit policy on `main`. Release Please-created branches receive automatically dispatched CI through `workflow_dispatch`, avoiding a PAT or GitHub App key.
 - A manual recovery dispatch may publish one missing package version only when given its exact canonical package tag. Recovery checks out and revalidates that tag, verifies dependency availability and registry state, and refuses to replace a version that already exists.
 - A bad published version is deprecated and followed by a corrected patch. Do not overwrite or routinely unpublish immutable package history.
 - Normal package releases are stable semver versions published to `latest`. The workflow does not support `next`, `beta`, or `rc` channels until a separate prerelease policy is accepted; the setup-only `bootstrap` tag is the sole exception.
@@ -179,7 +183,7 @@ The execution mode:
 3. Sets package publishing access to `mfa=publish`, which requires interactive 2FA and disallows automation-token publication while retaining OIDC publishing.
 4. Deprecates the bootstrap placeholder before configuring trust. The first trusted `0.1.0` publish replaces `latest` with the real release.
 5. Configures and verifies each package with `npm trust github`, pinned to `OpenWaggle/OpenWaggle`, `package-release.yml`, environment `npm`, and direct publish permission only.
-6. Creates or verifies the GitHub `npm` environment and additive `main` ruleset, then enforces merge commits off with squash and rebase on. The repository update sends only those three merge-mode fields and verifies the resulting state, so unrelated repository settings are not overwritten.
+6. Creates or verifies the GitHub `npm` environment and additive `main` ruleset with only the administrator emergency bypass, then enforces merge commits off with squash and rebase on. The repository update sends only those three merge-mode fields and verifies the resulting state, so unrelated repository settings are not overwritten.
 
 Source package manifests stay at the unpublished `0.0.0` baseline until Release Please creates the canonical `0.1.0` release PR. Every real package version, including `0.1.0`, is then published by CI with provenance.
 

--- a/docs/specs/issue-113-extension-host-ac-mapping.md
+++ b/docs/specs/issue-113-extension-host-ac-mapping.md
@@ -84,7 +84,7 @@ The current agreed direction:
 - `extension-sdk` and `waggle-core` publish before `extension-react` and `pi-waggle`, respectively.
 - A resumable one-time bootstrap may publish deprecated `0.0.0-bootstrap.0` placeholders under the non-default `bootstrap` dist-tag, then configure `npm trust` and package `mfa=publish`; this is not a real package release or local fallback.
 - The bootstrap command has read-only default behavior and requires `--execute` for external changes.
-- The GitHub `npm` environment has no npm secrets or required reviewers, permits `main` only, and is paired with an additive `main` ruleset requiring PRs and green CI while blocking force pushes and deletion. Bootstrap fails compatibility when repository merge modes drift, patches only the owned merge-mode fields, and verifies merge commits off with squash and rebase on.
+- The GitHub `npm` environment has no npm secrets or required reviewers, permits `main` only, and is paired with an additive `main` ruleset requiring PRs and green CI while blocking force pushes and deletion. The ruleset grants only the administrator emergency bypass; automated app version commits use a separately validated release PR instead of bypassing protection. Bootstrap fails compatibility when repository merge modes drift, patches only the owned merge-mode fields, and verifies merge commits off with squash and rebase on.
 - Release Please-generated PR branches receive automatically dispatched CI without a PAT or GitHub App secret.
 - Bad versions are deprecated and followed by a corrected patch rather than overwritten or routinely unpublished.
 - The OpenWaggle desktop app release workflow remains separate from npm package publishing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwaggle",
-  "version": "0.3.0-alpha.43",
+  "version": "0.3.0-alpha.44",
   "description": "Desktop coding agent with multi-model waggle mode",
   "main": "./out/main/index.js",
   "engines": {

--- a/scripts/__tests__/app-release-state.unit.test.ts
+++ b/scripts/__tests__/app-release-state.unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  expectedVersionOnlyManifest,
+  mergeRecoveryAction,
+  selectOwnedReleasePullRequests,
+  type AppReleasePullRequest,
+} from '../app-release-state'
+
+function pullRequest(
+  overrides: Partial<AppReleasePullRequest> = {},
+): AppReleasePullRequest {
+  return {
+    baseRefName: 'main',
+    headRefName: 'app-release-v0.3.0-alpha.45',
+    headRefOid: 'a'.repeat(40),
+    headRepository: { name: 'OpenWaggle' },
+    headRepositoryOwner: { login: 'OpenWaggle' },
+    isCrossRepository: false,
+    mergeCommit: null,
+    number: 123,
+    state: 'OPEN',
+    title: 'chore(release): v0.3.0-alpha.45',
+    url: 'https://github.com/OpenWaggle/OpenWaggle/pull/123',
+    ...overrides,
+  }
+}
+
+describe('app release state model', () => {
+  it('selects only the same-repository release PR', () => {
+    const selected = selectOwnedReleasePullRequests(
+      [
+        pullRequest(),
+        pullRequest({ isCrossRepository: true, number: 124 }),
+        pullRequest({ headRepositoryOwner: { login: 'attacker' }, number: 125 }),
+        pullRequest({ headRepository: { name: 'fork' }, number: 126 }),
+        pullRequest({ headRefName: 'another-branch', number: 127 }),
+      ],
+      {
+        branch: 'app-release-v0.3.0-alpha.45',
+        owner: 'OpenWaggle',
+        repository: 'OpenWaggle',
+      },
+    )
+
+    expect(selected.map(({ number }) => number)).toEqual([123])
+  })
+
+  it('creates an exact manifest with only the version changed', () => {
+    const base = '{\n  "name": "openwaggle",\n  "version": "0.3.0-alpha.44",\n  "private": true\n}\n'
+
+    expect(expectedVersionOnlyManifest(base, '0.3.0-alpha.45')).toBe(
+      '{\n  "name": "openwaggle",\n  "version": "0.3.0-alpha.45",\n  "private": true\n}\n',
+    )
+  })
+
+  it.each([
+    [{ state: 'MERGED', mergeStateStatus: 'UNKNOWN' }, 'complete'],
+    [{ state: 'OPEN', mergeStateStatus: 'BEHIND' }, 'retry'],
+    [{ state: 'OPEN', mergeStateStatus: 'UNKNOWN' }, 'poll'],
+    [{ state: 'OPEN', mergeStateStatus: 'BLOCKED' }, 'poll'],
+    [{ state: 'OPEN', mergeStateStatus: 'UNSTABLE' }, 'poll'],
+    [{ state: 'OPEN', mergeStateStatus: 'CLEAN' }, 'poll'],
+    [{ state: 'CLOSED', mergeStateStatus: 'UNKNOWN' }, 'conflict'],
+    [{ state: 'OPEN', mergeStateStatus: 'DIRTY' }, 'conflict'],
+  ])('maps merge recovery state %j to %s', (input, expected) => {
+    expect(mergeRecoveryAction(input)).toBe(expected)
+  })
+})

--- a/scripts/__tests__/app-release-workflow.unit.test.ts
+++ b/scripts/__tests__/app-release-workflow.unit.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { assertMatching } from '@diegogbrisa/ts-match'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const PROJECT_ROOT = process.cwd()
+const WORKFLOW = fs.readFileSync(
+  path.join(PROJECT_ROOT, '.github/workflows/release.yml'),
+  'utf8',
+)
+const ROOT_PACKAGE = fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf8')
+
+describe('desktop app release workflow', () => {
+  it('grants write permissions only to orchestration and publication jobs', () => {
+    const parsed: unknown = parse(WORKFLOW)
+
+    assertMatching(
+      {
+        jobs: {
+          release: { permissions: { contents: 'write' } },
+          version: {
+            permissions: {
+              actions: 'write',
+              contents: 'write',
+              'pull-requests': 'write',
+            },
+          },
+        },
+        permissions: { contents: 'read' },
+      },
+      parsed,
+    )
+  })
+
+  it('merges a validated version PR instead of bypassing main protection', () => {
+    expect(WORKFLOW).not.toContain('git push origin main')
+    expect(WORKFLOW).not.toContain('--admin')
+    expect(WORKFLOW).toContain('git push origin "$RELEASE_BRANCH"')
+    expect(WORKFLOW).toContain('gh pr create')
+    expect(WORKFLOW).toContain('gh workflow run ci.yml --ref "$RELEASE_BRANCH"')
+    expect(WORKFLOW).toContain('-f "head_sha=${HEAD_SHA}"')
+    expect(WORKFLOW).toContain('gh run watch "$RUN_ID" --exit-status')
+    expect(WORKFLOW).toContain('--match-head-commit "$HEAD_SHA"')
+    expect(WORKFLOW).toContain('--squash')
+  })
+
+  it('tags only the verified protected merge commit', () => {
+    expect(WORKFLOW).toContain('git merge-base --is-ancestor "$commit_sha" origin/main')
+    expect(WORKFLOW).toContain(
+      'test "$(git show -s --format=%s "$commit_sha")" = "chore(release): v${VERSION}"',
+    )
+    expect(WORKFLOW).toContain('git tag -a "$TAG" "$MERGE_SHA"')
+    expect(WORKFLOW).toContain('git push origin "refs/tags/${TAG}"')
+    expect(WORKFLOW).not.toContain('--follow-tags')
+  })
+
+  it('resumes compatible durable state and retries stale-base validation', () => {
+    expect(WORKFLOW).toContain('gh pr list --state all --head "$RELEASE_BRANCH"')
+    expect(WORKFLOW).toContain('scripts/app-release-state.ts filter-prs')
+    expect(WORKFLOW).toContain('if [ "$PR_STATE" = "MERGED" ]')
+    expect(WORKFLOW).toContain('if [ "$MERGE_STATE" = "BEHIND" ]')
+    expect(WORKFLOW).toContain('/update-branch')
+    expect(WORKFLOW).toContain('for MERGE_ATTEMPT in $(seq 1 3)')
+    expect(WORKFLOW).toContain('for STATE_ATTEMPT in $(seq 1 30)')
+    expect(WORKFLOW).toContain('test "$(git rev-list -n 1 "$TAG")" = "$MERGE_SHA"')
+    expect(WORKFLOW).toContain('verify_release_commit "$TAG_COMMIT"')
+  })
+
+  it('accepts no candidate package changes beyond the expected version', () => {
+    expect(WORKFLOW).toContain('verify_version_only_tree()')
+    expect(WORKFLOW).toContain('scripts/app-release-state.ts expected-manifest')
+    expect(WORKFLOW).toContain(
+      'cmp "$RUNNER_TEMP/expected-package.json" "$RUNNER_TEMP/candidate-package.json"',
+    )
+    expect(WORKFLOW).toContain('verify_version_only_tree "$parent_sha" "$commit_sha"')
+    expect(WORKFLOW).toContain(
+      'verify_version_only_tree "origin/main" "origin/${RELEASE_BRANCH}"',
+    )
+  })
+
+  it('keeps the alpha.44 orphan-tag recovery from creating another release', () => {
+    expect(ROOT_PACKAGE).toContain('"version": "0.3.0-alpha.44"')
+    expect(WORKFLOW).toContain(
+      `if: "!startsWith(github.event.head_commit.message, 'chore(release):')"`,
+    )
+    expect(WORKFLOW).toContain('NEW_VERSION="${BASE_VERSION}-${PRERELEASE_TAG}.$((PRERELEASE_NUM + 1))"')
+  })
+
+  it('pins every referenced action to an immutable commit', () => {
+    const actionReferences = [...WORKFLOW.matchAll(/\buses:\s*([^\s#]+)/gu)].map(
+      (match) => match[1],
+    )
+
+    expect(actionReferences.length).toBeGreaterThan(0)
+    for (const reference of actionReferences) {
+      expect(reference).toMatch(/^[^@\s]+@[0-9a-f]{40}$/u)
+    }
+  })
+})

--- a/scripts/__tests__/app-release-workflow.unit.test.ts
+++ b/scripts/__tests__/app-release-workflow.unit.test.ts
@@ -9,8 +9,6 @@ const WORKFLOW = fs.readFileSync(
   path.join(PROJECT_ROOT, '.github/workflows/release.yml'),
   'utf8',
 )
-const ROOT_PACKAGE = fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf8')
-
 describe('desktop app release workflow', () => {
   it('grants write permissions only to orchestration and publication jobs', () => {
     const parsed: unknown = parse(WORKFLOW)
@@ -79,8 +77,7 @@ describe('desktop app release workflow', () => {
     )
   })
 
-  it('keeps the alpha.44 orphan-tag recovery from creating another release', () => {
-    expect(ROOT_PACKAGE).toContain('"version": "0.3.0-alpha.44"')
+  it('skips release orchestration commits and increments prerelease versions', () => {
     expect(WORKFLOW).toContain(
       `if: "!startsWith(github.event.head_commit.message, 'chore(release):')"`,
     )

--- a/scripts/app-release-state.ts
+++ b/scripts/app-release-state.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { match } from '@diegogbrisa/ts-match'
+import { Schema } from 'effect'
+
+const ARG_VALUE_OFFSET = 1
+const CLI_COMMAND_INDEX = 2
+const JSON_INDENT = 2
+
+const pullRequestSchema = Schema.Struct({
+  baseRefName: Schema.String,
+  headRefName: Schema.String,
+  headRefOid: Schema.String,
+  headRepository: Schema.Struct({ name: Schema.String }),
+  headRepositoryOwner: Schema.Struct({ login: Schema.String }),
+  isCrossRepository: Schema.Boolean,
+  mergeCommit: Schema.NullOr(Schema.Struct({ oid: Schema.String })),
+  number: Schema.Number,
+  state: Schema.String,
+  title: Schema.String,
+  url: Schema.String,
+})
+const pullRequestListJsonSchema = Schema.parseJson(Schema.Array(pullRequestSchema))
+const manifestJsonSchema = Schema.parseJson(
+  Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+)
+
+export type AppReleasePullRequest = typeof pullRequestSchema.Type
+
+export interface ReleasePullRequestIdentity {
+  readonly branch: string
+  readonly owner: string
+  readonly repository: string
+}
+
+export interface MergeRecoveryInput {
+  readonly mergeStateStatus: string
+  readonly state: string
+}
+
+export type MergeRecoveryAction = 'complete' | 'conflict' | 'poll' | 'retry'
+
+export function selectOwnedReleasePullRequests(
+  pullRequests: readonly AppReleasePullRequest[],
+  identity: ReleasePullRequestIdentity,
+) {
+  return pullRequests.filter(
+    (pullRequest) =>
+      pullRequest.isCrossRepository === false &&
+      pullRequest.headRepositoryOwner.login === identity.owner &&
+      pullRequest.headRepository.name === identity.repository &&
+      pullRequest.headRefName === identity.branch,
+  )
+}
+
+export function expectedVersionOnlyManifest(baseManifestJson: string, version: string) {
+  const manifest = Schema.decodeUnknownSync(manifestJsonSchema)(baseManifestJson)
+  return `${JSON.stringify({ ...manifest, version }, null, JSON_INDENT)}\n`
+}
+
+export function mergeRecoveryAction(input: MergeRecoveryInput): MergeRecoveryAction {
+  return match(input)
+    .when(
+      ({ state }) => state === 'MERGED',
+      () => 'complete' as const,
+    )
+    .when(
+      ({ mergeStateStatus, state }) => state === 'OPEN' && mergeStateStatus === 'BEHIND',
+      () => 'retry' as const,
+    )
+    .when(
+      ({ mergeStateStatus, state }) =>
+        state === 'OPEN' &&
+        ['UNKNOWN', 'BLOCKED', 'UNSTABLE', 'CLEAN'].includes(mergeStateStatus),
+      () => 'poll' as const,
+    )
+    .otherwise(() => 'conflict' as const)
+}
+
+function argument(name: string) {
+  const index = process.argv.indexOf(name)
+  const value = index >= 0 ? process.argv[index + ARG_VALUE_OFFSET] : undefined
+  if (!value) {
+    throw new Error(`Missing required argument ${name}.`)
+  }
+  return value
+}
+
+async function readStandardInput() {
+  process.stdin.setEncoding('utf8')
+  let input = ''
+  for await (const chunk of process.stdin) {
+    input += String(chunk)
+  }
+  return input
+}
+
+async function runCli() {
+  const command = process.argv[CLI_COMMAND_INDEX]
+  if (command === 'filter-prs') {
+    const pullRequests = Schema.decodeUnknownSync(pullRequestListJsonSchema)(
+      await readStandardInput(),
+    )
+    const selected = selectOwnedReleasePullRequests(pullRequests, {
+      branch: argument('--branch'),
+      owner: argument('--owner'),
+      repository: argument('--repository'),
+    })
+    process.stdout.write(JSON.stringify(selected))
+    return
+  }
+
+  if (command === 'expected-manifest') {
+    const basePath = argument('--base')
+    const outputPath = argument('--output')
+    const version = argument('--version')
+    const expected = expectedVersionOnlyManifest(fs.readFileSync(basePath, 'utf8'), version)
+    fs.writeFileSync(outputPath, expected)
+    return
+  }
+
+  if (command === 'merge-action') {
+    process.stdout.write(
+      mergeRecoveryAction({
+        mergeStateStatus: argument('--merge-state'),
+        state: argument('--state'),
+      }),
+    )
+    return
+  }
+
+  throw new Error(`Unsupported app release state command: ${String(command)}.`)
+}
+
+const entryPath = process.argv[1]
+if (entryPath && import.meta.url === pathToFileURL(entryPath).href) {
+  void runCli().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

- replace direct protected-main mutation with a resumable release PR workflow
- require exact-head CI before merging the generated release PR through the normal ruleset
- verify the protected merge commit and version-only tree before creating the app tag
- preserve the orphaned `v0.3.0-alpha.44` tag and advance the next desktop release to `alpha.45`
- pin every release action to an immutable commit SHA

## Cause

The previous desktop release workflow attempted to push its version commit directly to protected `main`. The ruleset rejected that push after the workflow had already created `v0.3.0-alpha.44`, leaving an orphaned tag whose target is not on `main`.

## Validation

- `pnpm check`
- typed release-state unit tests
- release workflow structural tests
- helper CLI smoke
- extracted workflow shell `bash -n`
- independent read-only code review: no P0-P3 findings
