### PR TITLE
fix(release): close recovery and runtime gaps

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -444,7 +444,7 @@ jobs:
   release-qa:
     name: Package release QA (Node ${{ matrix.node }})
     needs: release-plan
-    if: ${{ needs.release-plan.result == 'success' }}
+    if: ${{ always() && needs.release-plan.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -502,7 +502,7 @@ jobs:
     needs:
       - release-plan
       - release-qa
-    if: ${{ needs.release-plan.result == 'success' && needs.release-qa.result == 'success' }}
+    if: ${{ always() && needs.release-plan.result == 'success' && needs.release-qa.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -642,7 +642,7 @@ jobs:
     needs:
       - release-plan
       - prepare-artifacts
-    if: ${{ needs.release-plan.result == 'success' && needs.prepare-artifacts.result == 'success' && needs.release-plan.outputs.has_bases == 'true' }}
+    if: ${{ always() && needs.release-plan.result == 'success' && needs.prepare-artifacts.result == 'success' && needs.release-plan.outputs.has_bases == 'true' }}
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -922,3 +922,52 @@ jobs:
           done
           echo "$PACKAGE_NAME@$PACKAGE_VERSION did not become readable from npm."
           exit 1
+
+  verify-release-outcome:
+    name: Verify package release outcome
+    needs:
+      - release-plan
+      - release-qa
+      - prepare-artifacts
+      - publish-bases
+      - publish-dependents
+    if: ${{ always() && needs.release-plan.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail closed on skipped or failed release jobs
+        env:
+          HAS_BASES: ${{ needs.release-plan.outputs.has_bases }}
+          HAS_DEPENDENTS: ${{ needs.release-plan.outputs.has_dependents }}
+          RELEASE_QA_RESULT: ${{ needs.release-qa.result }}
+          PREPARE_ARTIFACTS_RESULT: ${{ needs.prepare-artifacts.result }}
+          PUBLISH_BASES_RESULT: ${{ needs.publish-bases.result }}
+          PUBLISH_DEPENDENTS_RESULT: ${{ needs.publish-dependents.result }}
+        run: |
+          set -euo pipefail
+          case "$HAS_BASES" in
+            true|false) ;;
+            *) echo "Invalid has_bases release-plan output: $HAS_BASES"; exit 1 ;;
+          esac
+          case "$HAS_DEPENDENTS" in
+            true|false) ;;
+            *) echo "Invalid has_dependents release-plan output: $HAS_DEPENDENTS"; exit 1 ;;
+          esac
+          if [ "$HAS_BASES" != "true" ] && [ "$HAS_DEPENDENTS" != "true" ]; then
+            echo "Release plan did not select a package family."
+            exit 1
+          fi
+
+          test "$RELEASE_QA_RESULT" = "success"
+          test "$PREPARE_ARTIFACTS_RESULT" = "success"
+
+          if [ "$HAS_BASES" = "true" ]; then
+            test "$PUBLISH_BASES_RESULT" = "success"
+          else
+            test "$PUBLISH_BASES_RESULT" = "skipped"
+          fi
+
+          if [ "$HAS_DEPENDENTS" = "true" ]; then
+            test "$PUBLISH_DEPENDENTS_RESULT" = "success"
+          else
+            test "$PUBLISH_DEPENDENTS_RESULT" = "skipped"
+          fi

--- a/scripts/__tests__/package-release-validator-recovery.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-recovery.unit.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { validatePackageReleaseFiles } from '../package-release-validator'
+import {
+  validWorkflow,
+  writeMinimalPackageReleaseProject,
+} from './package-release-validator.fixtures'
+
+describe('package release recovery workflow validation', () => {
+  it('rejects recovery jobs that can be skipped by the Release Please ancestor', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(
+          "if: ${{ always() && needs.release-plan.result == 'success' }}",
+          "if: ${{ needs.release-plan.result == 'success' }}\n    env:\n      ALWAYS_DECOY: always()",
+        )
+        .replace(
+          "if: ${{ always() && needs.release-plan.result == 'success' && needs.release-qa.result == 'success' }}",
+          "if: ${{ needs.release-plan.result == 'success' && needs.release-qa.result == 'success' }}",
+        )
+        .replace(
+          "if: ${{ always() && needs.release-plan.result == 'success' && needs.prepare-artifacts.result == 'success' && needs.release-plan.outputs.has_bases == 'true' }}",
+          "if: ${{ needs.release-plan.result == 'success' && needs.prepare-artifacts.result == 'success' && needs.release-plan.outputs.has_bases == 'true' }}",
+        )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toEqual(
+        expect.arrayContaining([
+          '.github/workflows/package-release.yml release-qa must run after skipped Release Please during recovery.',
+          '.github/workflows/package-release.yml prepare-artifacts must run after successful recovery QA.',
+          '.github/workflows/package-release.yml publish-bases must run after successful recovery artifact preparation.',
+        ]),
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects weakened or inverted terminal release auditing', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(
+          "if: ${{ always() && needs.release-plan.result == 'success' }}\n    runs-on: ubuntu-latest\n    steps:\n      - name: Fail closed on skipped or failed release jobs",
+          "if: ${{ always() }}\n    runs-on: ubuntu-latest\n    steps:\n      - name: Fail closed on skipped or failed release jobs",
+        )
+        .replace('[ "$HAS_BASES" = "true" ]', '[ "$HAS_BASES" = "false" ]')
+        .replace('test "$PUBLISH_DEPENDENTS_RESULT" = "skipped"', 'true')
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/package-release.yml release outcome audit must match its exact fail-closed contract.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/__tests__/rebuild-native-deps.unit.test.ts
+++ b/scripts/__tests__/rebuild-native-deps.unit.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   createNativeRebuildCacheKey,
   commandInvocationForPlatform,
+  electronRuntimeInstallCommandForPlatform,
+  ensureNativeProbeRuntime,
   isNativeRebuildForceEnabled,
   isNativeRebuildMarkerFresh,
   nativeArtifactPackagesForMode,
@@ -85,6 +87,99 @@ describe('native dependency rebuild cache', () => {
       args: ['--import', 'tsx', 'C:\\workspace\\scripts\\native-load-probe.ts', 'electron'],
       environment: expect.objectContaining({ ELECTRON_RUN_AS_NODE: '1' }),
     })
+  })
+
+  it('installs a missing Electron runtime with Node and no shell wrapper', () => {
+    expect(
+      electronRuntimeInstallCommandForPlatform('C:\\workspace', 'win32', 'C:\\node.exe'),
+    ).toEqual({
+      command: 'C:\\node.exe',
+      args: ['C:\\workspace\\node_modules\\electron\\install.js'],
+    })
+  })
+
+  it.each([
+    [
+      'darwin',
+      '/workspace/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
+      '/workspace/node_modules/electron/install.js',
+    ],
+    [
+      'linux',
+      '/workspace/node_modules/electron/dist/electron',
+      '/workspace/node_modules/electron/install.js',
+    ],
+    [
+      'win32',
+      'C:\\workspace\\node_modules\\electron\\dist\\electron.exe',
+      'C:\\workspace\\node_modules\\electron\\install.js',
+    ],
+  ] as const)(
+    'installs a missing Electron runtime on %s',
+    async (platform, expectedExecutable, expectedInstaller) => {
+      const projectRoot = platform === 'win32' ? 'C:\\workspace' : '/workspace'
+      const accesses: string[] = []
+      const invocations: { readonly command: string; readonly args: readonly string[] }[] = []
+
+      await ensureNativeProbeRuntime('electron', {
+        projectRoot,
+        platform,
+        nodeExecutable: platform === 'win32' ? 'C:\\node.exe' : '/usr/bin/node',
+        accessPath: async (filePath) => {
+          accesses.push(filePath)
+          throw new Error('missing')
+        },
+        runInstall: async (command, args) => {
+          invocations.push({ command, args })
+        },
+      })
+
+      expect(accesses).toEqual([expectedExecutable])
+      expect(invocations).toEqual([
+        {
+          command: platform === 'win32' ? 'C:\\node.exe' : '/usr/bin/node',
+          args: [expectedInstaller],
+        },
+      ])
+    },
+  )
+
+  it('does not install Electron when its runtime exists or the probe targets Node', async () => {
+    const accesses: string[] = []
+    const installs: string[] = []
+    const options = {
+      projectRoot: '/workspace',
+      platform: 'linux' as const,
+      nodeExecutable: '/usr/bin/node',
+      accessPath: async (filePath: string) => {
+        accesses.push(filePath)
+      },
+      runInstall: async (command: string) => {
+        installs.push(command)
+      },
+    }
+
+    await ensureNativeProbeRuntime('electron', options)
+    await ensureNativeProbeRuntime('node', options)
+
+    expect(accesses).toEqual(['/workspace/node_modules/electron/dist/electron'])
+    expect(installs).toEqual([])
+  })
+
+  it('propagates Electron runtime installation failures', async () => {
+    await expect(
+      ensureNativeProbeRuntime('electron', {
+        projectRoot: '/workspace',
+        platform: 'linux',
+        nodeExecutable: '/usr/bin/node',
+        accessPath: async () => {
+          throw new Error('missing')
+        },
+        runInstall: async () => {
+          throw new Error('download failed')
+        },
+      }),
+    ).rejects.toThrow('download failed')
   })
 
   it('invokes Windows command wrappers explicitly without enabling spawn shell parsing', () => {

--- a/scripts/package-release-validator-recovery.ts
+++ b/scripts/package-release-validator-recovery.ts
@@ -1,0 +1,96 @@
+import { runsCommandFragment } from './package-release-validator-workflow-structure'
+import {
+  workflowJobCondition,
+  workflowJobNeeds,
+  workflowJobRunCommands,
+} from './package-release-validator-workflow-steps'
+
+const EMPTY_COUNT = 0
+const EXPECTED_PUBLISH_COMMAND_COUNT = 2
+const WORKFLOW_PATH = '.github/workflows/package-release.yml'
+
+const RECOVERY_JOBS = [
+  {
+    name: 'release-qa',
+    condition: "${{ always() && needs.release-plan.result == 'success' }}",
+    message: `${WORKFLOW_PATH} release-qa must run after skipped Release Please during recovery.`,
+  },
+  {
+    name: 'prepare-artifacts',
+    condition: "${{ always() && needs.release-plan.result == 'success' && needs.release-qa.result == 'success' }}",
+    message: `${WORKFLOW_PATH} prepare-artifacts must run after successful recovery QA.`,
+  },
+  {
+    name: 'publish-bases',
+    condition: "${{ always() && needs.release-plan.result == 'success' && needs.prepare-artifacts.result == 'success' && needs.release-plan.outputs.has_bases == 'true' }}",
+    message: `${WORKFLOW_PATH} publish-bases must run after successful recovery artifact preparation.`,
+  },
+] as const
+
+const OUTCOME_CONDITION = "${{ always() && needs.release-plan.result == 'success' }}"
+const OUTCOME_NEEDS = ['release-plan', 'release-qa', 'prepare-artifacts', 'publish-bases', 'publish-dependents'] as const
+const OUTCOME_AUDIT = `set -euo pipefail
+case "$HAS_BASES" in
+  true|false) ;;
+  *) echo "Invalid has_bases release-plan output: $HAS_BASES"; exit 1 ;;
+esac
+case "$HAS_DEPENDENTS" in
+  true|false) ;;
+  *) echo "Invalid has_dependents release-plan output: $HAS_DEPENDENTS"; exit 1 ;;
+esac
+if [ "$HAS_BASES" != "true" ] && [ "$HAS_DEPENDENTS" != "true" ]; then
+  echo "Release plan did not select a package family."
+  exit 1
+fi
+
+test "$RELEASE_QA_RESULT" = "success"
+test "$PREPARE_ARTIFACTS_RESULT" = "success"
+
+if [ "$HAS_BASES" = "true" ]; then
+  test "$PUBLISH_BASES_RESULT" = "success"
+else
+  test "$PUBLISH_BASES_RESULT" = "skipped"
+fi
+
+if [ "$HAS_DEPENDENTS" = "true" ]; then
+  test "$PUBLISH_DEPENDENTS_RESULT" = "success"
+else
+  test "$PUBLISH_DEPENDENTS_RESULT" = "skipped"
+fi`
+
+function addViolation(condition: boolean, message: string, violations: string[]) {
+  if (condition) violations.push(message)
+}
+
+export function validateWorkflowRecovery(
+  workflowRoot: unknown,
+  workflowText: string,
+  violations: string[],
+) {
+  const canonicalTag = runsCommandFragment(workflowText, '^(extension-sdk|extension-react|waggle-core|pi-waggle)-v(0|[1-9][0-9]*)')
+  const resolvesTag = runsCommandFragment(workflowText, 'git rev-parse "refs/tags/${tag}^{commit}"') || runsCommandFragment(workflowText, 'git rev-parse "refs/tags/${RECOVERY_TAG}^{commit}"')
+  addViolation(!canonicalTag || !resolvesTag, `${WORKFLOW_PATH} must recover only one exact canonical package tag.`, violations)
+  addViolation(!/^\s+ref: refs\/tags\/\$\{\{ inputs\.package_tag \}\}\s*$/m.test(workflowText), `${WORKFLOW_PATH} recovery must checkout the exact tag ref.`, violations)
+  const remoteTagVerified = runsCommandFragment(workflowText, 'git ls-remote --exit-code origin "refs/tags/$RECOVERY_TAG"') && (runsCommandFragment(workflowText, '"$REMOTE_TAG_SHA" != "$SOURCE_SHA"') || runsCommandFragment(workflowText, 'test "$REMOTE_TAG_SHA" = "$SOURCE_SHA"'))
+  addViolation(!remoteTagVerified, `${WORKFLOW_PATH} recovery must verify the remote GitHub tag SHA.`, violations)
+  const sourceVersionVerified = workflowText.includes('test "$actual_version" = "$RECOVERY_VERSION"') || (workflowText.includes('actual_version=$(node') && workflowText.includes('"$actual_version" != "$version"'))
+  addViolation(!sourceVersionVerified, `${WORKFLOW_PATH} recovery must verify source package version correspondence.`, violations)
+  addViolation(!runsCommandFragment(workflowText, 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag"'), `${WORKFLOW_PATH} recovery must verify the exact GitHub Release.`, violations)
+  addViolation((workflowText.match(/is already published\./g)?.length ?? EMPTY_COUNT) < EXPECTED_PUBLISH_COMMAND_COUNT, `${WORKFLOW_PATH} recovery must refuse already-published versions.`, violations)
+
+  for (const job of RECOVERY_JOBS) {
+    addViolation(
+      workflowJobCondition(workflowRoot, job.name) !== job.condition,
+      job.message,
+      violations,
+    )
+  }
+
+  const outcomeNeeds = workflowJobNeeds(workflowRoot, 'verify-release-outcome')
+  const outcomeRuns = workflowJobRunCommands(workflowRoot, 'verify-release-outcome')
+  const outcomeIsExact = workflowJobCondition(workflowRoot, 'verify-release-outcome') === OUTCOME_CONDITION &&
+    outcomeNeeds.length === OUTCOME_NEEDS.length &&
+    OUTCOME_NEEDS.every((jobName) => outcomeNeeds.includes(jobName)) &&
+    outcomeRuns.length === 1 && outcomeRuns[0]?.trim() === OUTCOME_AUDIT
+  addViolation(!outcomeIsExact, `${WORKFLOW_PATH} release outcome audit must match its exact fail-closed contract.`, violations)
+}

--- a/scripts/package-release-validator-workflow-steps.ts
+++ b/scripts/package-release-validator-workflow-steps.ts
@@ -13,6 +13,37 @@ function workflowJobSteps(workflowRoot: unknown, jobName: string) {
   return isSeq(steps) ? steps.items : []
 }
 
+function scalarString(node: unknown): string | undefined {
+  return isScalar(node) && typeof node.value === 'string' ? node.value : undefined
+}
+
+export function workflowJobCondition(
+  workflowRoot: unknown,
+  jobName: string,
+): string | undefined {
+  return scalarString(mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'if'))
+}
+
+export function workflowJobNeeds(workflowRoot: unknown, jobName: string): readonly string[] {
+  const needs = mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'needs')
+  if (isScalar(needs) && typeof needs.value === 'string') return [needs.value]
+  if (!isSeq(needs)) return []
+  return needs.items.flatMap((item) => {
+    const name = scalarString(item)
+    return name === undefined ? [] : [name]
+  })
+}
+
+export function workflowJobRunCommands(
+  workflowRoot: unknown,
+  jobName: string,
+): readonly string[] {
+  return workflowJobSteps(workflowRoot, jobName).flatMap((step) => {
+    const command = scalarString(mapValue(step, 'run'))
+    return command === undefined ? [] : [command]
+  })
+}
+
 function isDedicatedExactRunStep(step: unknown, command: string) {
   const run = mapValue(step, 'run')
   return (

--- a/scripts/package-release-validator-workflow-structure.ts
+++ b/scripts/package-release-validator-workflow-structure.ts
@@ -168,7 +168,7 @@ const PACKAGE_MANAGER_SETUP_ACTION = 'pnpm/action-setup@'
 const INSTALL_COMMAND_PATTERN = /(?:^|\s)(?:npm|pnpm|yarn|bun)\s+(?:add|install)(?:\s|$)/
 
 const PUBLICATION_JOB_HASHES = {
-  'publish-bases': 'cde731bc4794b22c5e858c2a88e24540ae712d6cb18d199a55ab20a940259c82',
+  'publish-bases': 'e0b23bd2bf7cc82f4450de40132ea50dfc96be6fa5fa4c124322544e2abe6814',
   'publish-dependents': 'e434cbd3c68d8fbcc79387897abdfbcd5cf09c175379b208341be7bed815f717',
 } as const
 

--- a/scripts/package-release-validator.ts
+++ b/scripts/package-release-validator.ts
@@ -14,12 +14,13 @@ import {
   jobHasDedicatedExactRunStep,
   jobHasDedicatedExactRunStepWithEnv,
 } from './package-release-validator-workflow-steps'
+import { validateWorkflowRecovery } from './package-release-validator-recovery'
 
 type JsonObject = { readonly [key: string]: unknown }
 interface ExpectedPackage { readonly component: string; readonly dependency?: string; readonly name: string; readonly path: string }
 export interface PackageReleaseValidationResult { readonly violations: readonly string[] }
 
-const FAILURE_EXIT_CODE = 1; const EMPTY_COUNT = 0; const EXPECTED_PUBLISH_COMMAND_COUNT = 2
+const FAILURE_EXIT_CODE = 1; const EMPTY_COUNT = 0
 const JOB_INDENT_WIDTH = 2; const BOOTSTRAP_SOURCE_VERSION = '0.0.0'; const INITIAL_PUBLIC_PACKAGE_VERSION = '0.1.0'
 const CONFIG_PATH = 'release-please-config.json'; const MANIFEST_PATH = '.release-please-manifest.json'
 const WORKFLOW_PATH = '.github/workflows/package-release.yml'; const CI_WORKFLOW_PATH = '.github/workflows/ci.yml'; const ROOT_PACKAGE_PATH = 'package.json'
@@ -268,19 +269,6 @@ function validateWorkflowPublication(workflowRoot: unknown, workflowText: string
   addViolation(!runsCommandFragment(dependents, 'npm view "$DEPENDENCY_NAME@$DEPENDENCY_VERSION" version'), `${WORKFLOW_PATH} must verify base package availability before dependent publication.`, violations)
 }
 
-function validateWorkflowRecovery(workflowText: string, violations: string[]) {
-  const canonicalTag = runsCommandFragment(workflowText, '^(extension-sdk|extension-react|waggle-core|pi-waggle)-v(0|[1-9][0-9]*)')
-  const resolvesTag = runsCommandFragment(workflowText, 'git rev-parse "refs/tags/${tag}^{commit}"') || runsCommandFragment(workflowText, 'git rev-parse "refs/tags/${RECOVERY_TAG}^{commit}"')
-  addViolation(!canonicalTag || !resolvesTag, `${WORKFLOW_PATH} must recover only one exact canonical package tag.`, violations)
-  addViolation(!/^\s+ref: refs\/tags\/\$\{\{ inputs\.package_tag \}\}\s*$/m.test(workflowText), `${WORKFLOW_PATH} recovery must checkout the exact tag ref.`, violations)
-  const remoteTagVerified = runsCommandFragment(workflowText, 'git ls-remote --exit-code origin "refs/tags/$RECOVERY_TAG"') && (runsCommandFragment(workflowText, '"$REMOTE_TAG_SHA" != "$SOURCE_SHA"') || runsCommandFragment(workflowText, 'test "$REMOTE_TAG_SHA" = "$SOURCE_SHA"'))
-  addViolation(!remoteTagVerified, `${WORKFLOW_PATH} recovery must verify the remote GitHub tag SHA.`, violations)
-  const sourceVersionVerified = workflowText.includes('test "$actual_version" = "$RECOVERY_VERSION"') || (workflowText.includes('actual_version=$(node') && workflowText.includes('"$actual_version" != "$version"'))
-  addViolation(!sourceVersionVerified, `${WORKFLOW_PATH} recovery must verify source package version correspondence.`, violations)
-  addViolation(!runsCommandFragment(workflowText, 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag"'), `${WORKFLOW_PATH} recovery must verify the exact GitHub Release.`, violations)
-  addViolation((workflowText.match(/is already published\./g)?.length ?? EMPTY_COUNT) < EXPECTED_PUBLISH_COMMAND_COUNT, `${WORKFLOW_PATH} recovery must refuse already-published versions.`, violations)
-}
-
 function validateWorkflowText(workflowText: string, violations: string[]) {
   const workflow = parsePackageReleaseWorkflow(workflowText)
   for (const error of workflow.errors) violations.push(`${WORKFLOW_PATH} must contain valid YAML: ${error}`)
@@ -288,7 +276,7 @@ function validateWorkflowText(workflowText: string, violations: string[]) {
   validateWorkflowActions(workflow.root, violations); validateNoFailOpenSteps(executableText, violations)
   validateWorkflowPermissions(executableText, violations); validateWorkflowConsumerSmoke(workflow.root, executableText, violations)
   validateWorkflowPathsAndDispatch(executableText, violations); validateWorkflowPublication(workflow.root, executableText, violations)
-  validateWorkflowRecovery(executableText, violations)
+  validateWorkflowRecovery(workflow.root, executableText, violations)
   for (const command of ['pnpm package-release:validate', 'pnpm check', 'pnpm build:packages']) addViolation(!jobHasDedicatedExactRunStep(workflow.root, 'validate-dry-run', command), `${WORKFLOW_PATH} must execute ${command}.`, violations)
   const snippets = ['workflow_dispatch:', 'package_tag:', "inputs.package_tag == ''", "inputs.package_tag != ''", `config-file: ${CONFIG_PATH}`, `manifest-file: ${MANIFEST_PATH}`, 'id-token: write', 'environment: npm', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'ACTIONS_ID_TOKEN_REQUEST_URL', 'npm install --global npm@11.18.0', 'node scripts/package-release-publish.ts "$TARBALL"', 'node-version: 24.14.0', 'test "$(npm --version)" = "11.9.0"', 'paths_released', "matrix.released == 'true'", 'fail-fast: false', 'tar -xOf "$TARBALL" package/package.json', 'npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version', 'npm view "$DEPENDENCY_NAME@$DEPENDENCY_VERSION" version', 'pnpm package-release:validate', 'pnpm check', 'pnpm build:packages', "github.event_name == 'push'", "github.ref == 'refs/heads/main'", 'group: package-release', 'cancel-in-progress: false']
   requireText(executableText, snippets.map((snippet) => [snippet, `${WORKFLOW_PATH} must contain ${snippet}.`]), violations)

--- a/scripts/rebuild-native-deps.ts
+++ b/scripts/rebuild-native-deps.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { access } from 'node:fs/promises'
 import { dirname, join, posix, win32 } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import {
@@ -49,6 +50,18 @@ type RebuildOptions = {
 type CommandInvocation = {
   readonly command: string
   readonly args: readonly string[]
+}
+
+type NativeProbeRuntimeOptions = {
+  readonly projectRoot?: string
+  readonly platform?: NodeJS.Platform
+  readonly nodeExecutable?: string
+  readonly accessPath?: (filePath: string) => Promise<void>
+  readonly runInstall?: (
+    command: string,
+    args: readonly string[],
+    extraEnvironment?: NodeJS.ProcessEnv,
+  ) => Promise<void>
 }
 
 export function commandInvocationForPlatform(
@@ -175,6 +188,43 @@ function electronExecutablePath(projectRoot: string, platform: NodeJS.Platform) 
   )
 }
 
+export function electronRuntimeInstallCommandForPlatform(
+  projectRoot: string = PROJECT_ROOT,
+  platform: NodeJS.Platform = process.platform,
+  nodeExecutable: string = process.execPath,
+): CommandInvocation {
+  const path = platform === 'win32' ? win32 : posix
+  return {
+    command: nodeExecutable,
+    args: [path.join(projectRoot, 'node_modules', 'electron', 'install.js')],
+  }
+}
+
+export async function ensureNativeProbeRuntime(
+  mode: RebuildMode,
+  options: NativeProbeRuntimeOptions = {},
+) {
+  if (mode === 'node') return
+  const projectRoot = options.projectRoot ?? PROJECT_ROOT
+  const platform = options.platform ?? process.platform
+  const accessPath = options.accessPath ?? access
+  const runInstall = options.runInstall ?? runCommand
+  try {
+    await accessPath(electronExecutablePath(projectRoot, platform))
+  } catch {
+    const install = electronRuntimeInstallCommandForPlatform(
+      projectRoot,
+      platform,
+      options.nodeExecutable ?? process.execPath,
+    )
+    await runInstall(
+      install.command,
+      install.args,
+      suppressDependencyDeprecationWarnings(),
+    )
+  }
+}
+
 export function nativeLoadProbeCommandForMode(
   mode: RebuildMode,
   projectRoot: string = PROJECT_ROOT,
@@ -197,11 +247,13 @@ export function nativeLoadProbeCommandForMode(
 }
 
 async function nativeLoadProbeSucceeds(mode: RebuildMode) {
+  await ensureNativeProbeRuntime(mode)
   const probe = nativeLoadProbeCommandForMode(mode)
   return commandSucceeds(probe.command, probe.args, probe.environment)
 }
 
 async function assertNativeLoadProbe(mode: RebuildMode) {
+  await ensureNativeProbeRuntime(mode)
   const probe = nativeLoadProbeCommandForMode(mode)
   await runCommand(probe.command, probe.args, probe.environment)
 }


### PR DESCRIPTION
## Summary
- make manual package recovery continue after skipped Release Please ancestors
- fail closed when a release plan does not complete its expected publication jobs
- structurally validate recovery conditions and the terminal audit contract
- install a missing Electron runtime payload before typed native-module probes

## Validation
- pnpm check
- pnpm test
- pnpm build
- independent code review: no residual findings