### PR TITLE
fix(release): harden package and installer verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  package-consumer-tools:
+    name: Package Consumer Tools (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - 22.19.0
+          - 24
+    steps:
+      - name: Checkout exact CI revision
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.sha }}
+
+      - name: Set up pinned pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.6.0
+
+      - name: Set up matrix Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install pinned package manager consumers
+        run: node scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"
+
+      - name: Verify package manager consumer versions
+        run: node scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"
+
   commit-policy:
     name: Commit Policy
     runs-on: ubuntu-latest

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -457,6 +457,14 @@ jobs:
         with:
           ref: ${{ needs.release-plan.outputs.source_sha }}
 
+      - name: Checkout immutable package consumer tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          sparse-checkout: scripts/package-consumer-tools.ts
+          sparse-checkout-cone-mode: false
+
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 11.6.0
@@ -473,16 +481,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Install pinned package manager consumers
-        run: |
-          npm install --global npm@11.18.0
-          corepack install --global yarn@4.17.1
+        run: node .release-tooling/scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"
 
       - name: Verify package manager consumer versions
-        run: |
-          test "$(npm --version)" = "11.18.0"
-          test "$(pnpm --version)" = "11.6.0"
-          test "$(cd "$RUNNER_TEMP" && yarn --version)" = "4.17.1"
-          test "$(bun --version)" = "1.3.14"
+        run: node .release-tooling/scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"
 
       - name: Run full release checks on Node 24
         if: ${{ matrix.node == 24 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,6 +478,11 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: ${{ runner.temp }}/release/${{ matrix.platform }}
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: matrix.platform == 'windows'
+        with:
+          node-version: 24.14.0
+
       - name: Verify Linux installer
         if: matrix.platform == 'linux'
         shell: bash
@@ -549,21 +554,9 @@ jobs:
       - name: Verify Windows installer
         if: matrix.platform == 'windows'
         shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $version = '${{ needs.version.outputs.new_version }}'
-          $artifactDir = Join-Path "$env:RUNNER_TEMP\release" 'windows'
-          $asset = "openwaggle-$version-x64.exe"
-          $installer = Join-Path $artifactDir $asset
-          if (-not (Test-Path $installer)) { throw 'Installer download failed' }
-
-          Start-Process -FilePath $installer -ArgumentList '/S' -Wait
-          $paths = @(
-            "$env:LOCALAPPDATA\Programs\OpenWaggle\OpenWaggle.exe",
-            "$env:ProgramFiles\OpenWaggle\OpenWaggle.exe"
-          )
-          $found = $paths | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $found) { throw 'Installed executable not found after silent install' }
+        env:
+          INSTALLER_PATH: ${{ runner.temp }}\release\windows\openwaggle-${{ needs.version.outputs.new_version }}-x64.exe
+        run: node scripts/verify-windows-installer.ts "$env:INSTALLER_PATH"
 
   release:
     name: Create GitHub Release

--- a/scripts/__tests__/app-release-workflow.unit.test.ts
+++ b/scripts/__tests__/app-release-workflow.unit.test.ts
@@ -95,4 +95,10 @@ describe('desktop app release workflow', () => {
       expect(reference).toMatch(/^[^@\s]+@[0-9a-f]{40}$/u)
     }
   })
+
+  it('verifies the Windows installer through the typed deterministic verifier', () => {
+    expect(WORKFLOW).toContain('node scripts/verify-windows-installer.ts "$env:INSTALLER_PATH"')
+    expect(WORKFLOW).toContain("INSTALLER_PATH: ${{ runner.temp }}\\release\\windows\\openwaggle-")
+    expect(WORKFLOW).not.toContain('Installed executable not found after silent install')
+  })
 })

--- a/scripts/__tests__/package-consumer-tools.unit.test.ts
+++ b/scripts/__tests__/package-consumer-tools.unit.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto'
+import { rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  installPackageConsumerTools,
+  verifyDownloadedPackageIntegrity,
+  verifyPackageConsumerTools,
+} from '../package-consumer-tools'
+
+describe('package consumer tools', () => {
+  it('pins the official registry, package integrities, and isolated install prefix', async () => {
+    const commands: { readonly command: string; readonly args: readonly string[] }[] = []
+    const pathWrites: { readonly filePath: string; readonly contents: string }[] = []
+    const verifiedPackages: { readonly filePath: string; readonly integrity: string }[] = []
+    await installPackageConsumerTools(
+      { toolRoot: '/tmp/tools', githubPath: '/tmp/github-path' },
+      {
+        runCommand: async (command, args) => {
+          commands.push({ command, args })
+          if (args[0] !== 'pack') return ''
+          const filename = args[1] === 'npm@11.18.0' ? 'npm-11.18.0.tgz' : 'yarnpkg-cli-dist-4.17.1.tgz'
+          return JSON.stringify([{ filename }])
+        },
+        appendSearchPath: async (filePath, contents) => {
+          pathWrites.push({ filePath, contents })
+        },
+        prepareDirectory: async () => undefined,
+        verifyDownloadedPackage: async (filePath, integrity) => {
+          verifiedPackages.push({ filePath, integrity })
+        },
+        writeUserConfig: async () => undefined,
+      },
+    )
+
+    expect(commands).toHaveLength(3)
+    expect(commands[0]?.args).toEqual(expect.arrayContaining([
+      'pack',
+      'npm@11.18.0',
+      '--json',
+      '--ignore-scripts',
+      '--pack-destination=/tmp/tools/downloads',
+      '--registry=https://registry.npmjs.org/',
+    ]))
+    expect(commands[1]?.args).toEqual(expect.arrayContaining([
+      'pack',
+      '@yarnpkg/cli-dist@4.17.1',
+      '--json',
+      '--ignore-scripts',
+      '--pack-destination=/tmp/tools/downloads',
+      '--registry=https://registry.npmjs.org/',
+    ]))
+    expect(commands[2]?.args).toEqual(expect.arrayContaining([
+      '--global',
+      '--ignore-scripts',
+      '--prefix=/tmp/tools',
+      '--registry=https://registry.npmjs.org/',
+      '/tmp/tools/downloads/npm-11.18.0.tgz',
+      '/tmp/tools/downloads/yarnpkg-cli-dist-4.17.1.tgz',
+    ]))
+    expect(verifiedPackages).toHaveLength(2)
+    expect(pathWrites).toEqual([{ filePath: '/tmp/github-path', contents: '/tmp/tools/bin\n' }])
+  })
+
+  it('fails before installation when downloaded package integrity changes', async () => {
+    await expect(installPackageConsumerTools(
+      { toolRoot: '/tmp/tools', githubPath: '/tmp/github-path' },
+      {
+        runCommand: async () => JSON.stringify([{ filename: 'package.tgz' }]),
+        appendSearchPath: async () => undefined,
+        prepareDirectory: async () => undefined,
+        verifyDownloadedPackage: async () => {
+          throw new Error('integrity mismatch')
+        },
+        writeUserConfig: async () => undefined,
+      },
+    )).rejects.toThrow('integrity mismatch')
+  })
+
+  it('computes SHA-512 over the downloaded tarball bytes', async () => {
+    const contents = Buffer.from('trusted package bytes')
+    const integrity = `sha512-${createHash('sha512').update(contents).digest('base64')}`
+    const filePath = join('/tmp', `openwaggle-integrity-${process.pid}.tgz`)
+    await writeFile(filePath, contents)
+    try {
+      await expect(verifyDownloadedPackageIntegrity(filePath, integrity)).resolves.toBeUndefined()
+      await expect(verifyDownloadedPackageIntegrity(filePath, 'sha512-untrusted')).rejects.toThrow(
+        'integrity mismatch',
+      )
+    } finally {
+      await rm(filePath, { force: true })
+    }
+  })
+
+  it('verifies isolated npm and Yarn plus existing pnpm and Bun versions', async () => {
+    const versions = new Map([
+      ['npm', '11.18.0'],
+      ['yarn', '4.17.1'],
+      ['pnpm', '11.6.0'],
+      ['bun', '1.3.14'],
+    ])
+    await verifyPackageConsumerTools('/tmp/tools', {
+      resolveExecutable: async (name) => name === 'npm' || name === 'yarn'
+        ? join('/tmp/tools', 'bin', name)
+        : `/usr/bin/${name}`,
+      runCommand: async (command) => versions.get(command.split('/').at(-1) ?? '') ?? '',
+    })
+  })
+})

--- a/scripts/__tests__/package-release-validator-consumers.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-consumers.unit.test.ts
@@ -1,0 +1,308 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { validatePackageReleaseFiles } from '../package-release-validator'
+import {
+  validCiWorkflow,
+  validWorkflow,
+  writeMinimalPackageReleaseProject,
+} from './package-release-validator.fixtures'
+
+describe('package release consumer tool validation', () => {
+  it('rejects npm and Yarn consumers that are not installed and resolved from an isolated path', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(
+          'run: node .release-tooling/scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"',
+          'env:\n          NODE_OPTIONS: --import=attacker.js\n        run: node .release-tooling/scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"',
+        )
+        .replace(
+          'run: node .release-tooling/scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"',
+          'if: ${{ false }}\n        run: node .release-tooling/scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"',
+        )
+        .replace(
+          '      - name: Install pinned package manager consumers',
+          '      - run: npx --yes npm@latest i -g npm@latest\n        if: ${{ false }}\n\n      - run: NPM=npm; $NPM i -g npm@latest\n        if: ${{ false }}\n\n      - name: Install pinned package manager consumers',
+        )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toEqual(
+        expect.arrayContaining([
+          '.github/workflows/package-release.yml release-qa must install npm and Yarn in an isolated runner path.',
+          '.github/workflows/package-release.yml release-qa must verify isolated npm and Yarn executable paths.',
+          '.github/workflows/package-release.yml release-qa must install package consumer tools only through the typed integrity-pinned installer.',
+        ]),
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects job-level execution injection and intermediate tooling modification', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(
+          '    runs-on: ubuntu-latest\n    strategy:\n      fail-fast: false',
+          '    runs-on: ubuntu-latest\n    env:\n      NODE_OPTIONS: --import=attacker.js\n    strategy:\n      fail-fast: false',
+        )
+        .replace(
+          '      - name: Install pinned package manager consumers',
+          '      - name: Modify checked-out release tooling\n        run: echo attacker >> .release-tooling/scripts/package-consumer-tools.ts\n\n      - name: Install pinned package manager consumers',
+        )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toEqual(
+        expect.arrayContaining([
+          '.github/workflows/package-release.yml release-qa must keep its exact blocking QA job contract.',
+          '.github/workflows/package-release.yml release-qa must install package consumer tools only through the typed integrity-pinned installer.',
+        ]),
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects package-release workflow execution injection and unexpected QA needs', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(
+          'permissions:\n  contents: read',
+          'env:\n  NODE_OPTIONS: --import=attacker.js\n\ndefaults:\n  run:\n    shell: bash\n\npermissions:\n  contents: read',
+        )
+        .replace('    needs: release-plan', '    needs: [release-plan, attacker]')
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toEqual(
+        expect.arrayContaining([
+          '.github/workflows/package-release.yml must omit workflow-level environment and defaults from package publishing.',
+          '.github/workflows/package-release.yml release-qa must keep its exact blocking QA job contract.',
+        ]),
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects package consumer tooling steps reordered after installation', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    const checkoutStep = `      - name: Checkout immutable package consumer tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: \${{ github.workflow_sha }}
+          path: .release-tooling
+          sparse-checkout: scripts/package-consumer-tools.ts
+          sparse-checkout-cone-mode: false`
+    const verifyStep = `      - name: Verify package manager consumer versions
+        run: node .release-tooling/scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"`
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(`${checkoutStep}\n\n`, '')
+        .replace(verifyStep, `${verifyStep}\n\n${checkoutStep}`)
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/package-release.yml release-qa must checkout tooling before installing and verifying package consumers.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects package consumer tooling not checked out from the workflow commit', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace('ref: ${{ github.workflow_sha }}', 'ref: ${{ needs.release-plan.outputs.source_sha }}')
+        .replace('sparse-checkout: scripts/package-consumer-tools.ts', 'sparse-checkout: scripts/other.ts')
+        .replace('sparse-checkout-cone-mode: false', 'sparse-checkout-cone-mode: true')
+        .replace(
+          '      - name: Checkout immutable package consumer tooling',
+          `      - name: Checkout immutable package consumer tooling
+        if: \${{ false }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: \${{ github.workflow_sha }}
+          path: .release-tooling
+          sparse-checkout: scripts/package-consumer-tools.ts
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout immutable package consumer tooling`,
+        )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/package-release.yml release-qa must checkout immutable package consumer tooling from the workflow commit.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects release QA using a source revision other than the release plan output', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow.replace(
+        'ref: ${{ needs.release-plan.outputs.source_sha }}',
+        'ref: ${{ github.workflow_sha }}',
+      )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/package-release.yml release-qa must execute exactly its approved source checkout, immutable tooling setup, and QA steps in order.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects extra release QA actions and environment injection', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow
+        .replace(
+          '      - name: Install pinned package manager consumers',
+          '      - uses: attacker/action@main\n\n      - name: Install pinned package manager consumers',
+        )
+        .replace(
+          "          OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1'",
+          "          OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1'\n          NODE_OPTIONS: --import=attacker.js",
+        )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toEqual(
+        expect.arrayContaining([
+          '.github/workflows/package-release.yml release-qa must execute exactly its approved source checkout, immutable tooling setup, and QA steps in order.',
+          '.github/workflows/package-release.yml release-qa must run browser-enabled package smoke on every Node matrix entry.',
+        ]),
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects CI without the exact Node 22.19 and Node 24 consumer-tool matrix', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidCiWorkflow = validCiWorkflow.replace(
+        / {2}package-consumer-tools:[\s\S]*?\n {2}commit-policy:/u,
+        '  commit-policy:',
+      )
+      await writeMinimalPackageReleaseProject(
+        projectRoot,
+        validWorkflow,
+        '0.1.0',
+        'released',
+        invalidCiWorkflow,
+      )
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toEqual(
+        expect.arrayContaining([
+          '.github/workflows/ci.yml package-consumer-tools must test exactly Node 22.19.0 and Node 24.',
+          '.github/workflows/ci.yml package-consumer-tools must execute its exact pinned setup, install, and verification steps in order.',
+        ]),
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a skipped or non-blocking CI consumer-tool matrix', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidCiWorkflow = validCiWorkflow.replace(
+        '  package-consumer-tools:\n    name: Package Consumer Tools (Node ${{ matrix.node }})\n    runs-on: ubuntu-latest',
+        '  package-consumer-tools:\n    name: Package Consumer Tools (Node ${{ matrix.node }})\n    if: false\n    continue-on-error: true\n    runs-on: ubuntu-latest',
+      )
+      await writeMinimalPackageReleaseProject(
+        projectRoot,
+        validWorkflow,
+        '0.1.0',
+        'released',
+        invalidCiWorkflow,
+      )
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/ci.yml package-consumer-tools must keep its exact blocking job contract.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects extra CI consumer-tool actions', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidCiWorkflow = validCiWorkflow.replace(
+        '      - name: Install pinned package manager consumers',
+        '      - uses: attacker/action@main\n\n      - name: Install pinned package manager consumers',
+      )
+      await writeMinimalPackageReleaseProject(
+        projectRoot,
+        validWorkflow,
+        '0.1.0',
+        'released',
+        invalidCiWorkflow,
+      )
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/ci.yml package-consumer-tools must contain exactly its approved pinned setup, install, and verification steps in order.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects CI workflow-level execution injection and defaults', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidCiWorkflow = validCiWorkflow
+        .replace(
+          '  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true',
+          '  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\n  NODE_OPTIONS: --import=attacker.js',
+        )
+        .replace(
+          'concurrency:',
+          'defaults:\n  run:\n    shell: bash\n\nconcurrency:',
+        )
+      await writeMinimalPackageReleaseProject(
+        projectRoot,
+        validWorkflow,
+        '0.1.0',
+        'released',
+        invalidCiWorkflow,
+      )
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/ci.yml must keep its exact workflow-level execution environment and omit workflow defaults.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/__tests__/package-release-validator-workflow.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-workflow.unit.test.ts
@@ -284,9 +284,11 @@ describe('package release workflow validation', () => {
     try {
       const invalidWorkflow = validWorkflow
         .replace('          - 22.19.0\n', '')
-        .replace('npm install --global npm@11.18.0', 'npm install --global npm@latest')
+        .replace(
+          'node .release-tooling/scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"',
+          'echo skipped-package-consumer-install',
+        )
         .replaceAll('version: 11.6.0', 'version: latest')
-        .replace('corepack install --global yarn@4.17.1', 'true')
         .replace('oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6', 'true')
         .replace(
           "OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'",
@@ -299,9 +301,7 @@ describe('package release workflow validation', () => {
       expect(result.violations).toEqual(
         expect.arrayContaining([
           '.github/workflows/package-release.yml release-qa must smoke consumers on Node 22.19.0 and Node 24.',
-          '.github/workflows/package-release.yml release-qa must pin npm 11.18.0.',
           '.github/workflows/package-release.yml release-qa must pin pnpm 11.6.0.',
-          '.github/workflows/package-release.yml release-qa must install Yarn 4.17.1.',
           '.github/workflows/package-release.yml must execute oven-sh/setup-bun at its approved immutable v2 SHA.',
           '.github/workflows/package-release.yml release-qa must require npm, pnpm, Yarn, and Bun package consumers.',
         ]),
@@ -311,22 +311,4 @@ describe('package release workflow validation', () => {
     }
   })
 
-  it('rejects Yarn version checks that run inside the pnpm workspace', async () => {
-    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
-    try {
-      const invalidWorkflow = validWorkflow.replace(
-        'test "$(cd "$RUNNER_TEMP" && yarn --version)" = "4.17.1"',
-        'test "$(yarn --version)" = "4.17.1"',
-      )
-      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
-
-      const result = await validatePackageReleaseFiles(projectRoot)
-
-      expect(result.violations).toContain(
-        '.github/workflows/package-release.yml release-qa must verify Yarn 4.17.1 outside the pnpm workspace before smoke testing.',
-      )
-    } finally {
-      await fs.rm(projectRoot, { recursive: true, force: true })
-    }
-  })
 })

--- a/scripts/__tests__/package-release-validator.fixtures.ts
+++ b/scripts/__tests__/package-release-validator.fixtures.ts
@@ -21,24 +21,10 @@ export const validWorkflow = readFileSync(
   'utf8',
 )
 
-const validCiWorkflow = `
-name: CI
-on:
-  workflow_dispatch:
-    inputs:
-      head_sha:
-        required: true
-        type: string
-jobs:
-  check:
-    steps:
-      - name: Verify dispatched commit identity
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          DISPATCHED_SHA: \${{ github.sha }}
-          EXPECTED_SHA: \${{ inputs.head_sha }}
-        run: test "$DISPATCHED_SHA" = "$EXPECTED_SHA"
-`
+export const validCiWorkflow = readFileSync(
+  path.join(process.cwd(), '.github/workflows/ci.yml'),
+  'utf8',
+)
 
 async function writeFile(filePath: string, contents: string) {
   await fs.mkdir(path.dirname(filePath), { recursive: true })
@@ -54,6 +40,7 @@ export async function writeMinimalPackageReleaseProject(
   workflowText: string,
   version = '0.1.0',
   manifestState: 'released' | 'bootstrap' = 'released',
+  ciWorkflowText = validCiWorkflow,
 ) {
   await writeJson(path.join(projectRoot, 'release-please-config.json'), {
     'release-type': 'node',
@@ -105,7 +92,7 @@ export async function writeMinimalPackageReleaseProject(
     },
   })
   await writeFile(path.join(projectRoot, '.github/workflows/package-release.yml'), workflowText)
-  await writeFile(path.join(projectRoot, '.github/workflows/ci.yml'), validCiWorkflow)
+  await writeFile(path.join(projectRoot, '.github/workflows/ci.yml'), ciWorkflowText)
 
   for (const [index, packageDirectory] of packageDirectories.entries()) {
     const dependencies =

--- a/scripts/__tests__/release-ci-policy.unit.test.ts
+++ b/scripts/__tests__/release-ci-policy.unit.test.ts
@@ -34,8 +34,14 @@ concurrency:
   group: ci-\${{ github.workflow }}-\${{ github.event.pull_request.number || inputs.head_sha || github.ref }}
   cancel-in-progress: true
 jobs:
+  package-consumer-tools:
+    name: Package Consumer Tools (Node \${{ matrix.node }})
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo validated-by-package-release-policy
   commit-policy:
     name: Commit Policy
+    runs-on: ubuntu-latest
     steps:
 ${dispatchIdentityGuard}      - uses: ${ACTION_CHECKOUT}
         with:
@@ -56,6 +62,7 @@ ${dispatchIdentityGuard}      - uses: ${ACTION_CHECKOUT}
         run: pnpm exec tsx scripts/check-conventional-commits.ts --from "$COMMIT_POLICY_FROM" --to "$COMMIT_POLICY_TO" --pr-title "$PR_TITLE"
   check:
     name: Typecheck & Lint
+    runs-on: ubuntu-latest
     steps:
 ${dispatchIdentityGuard}      - uses: ${ACTION_CHECKOUT}
         with:
@@ -69,6 +76,7 @@ ${dispatchIdentityGuard}      - uses: ${ACTION_CHECKOUT}
       - run: pnpm check
   test:
     name: Unit & Component Tests
+    runs-on: ubuntu-latest
     steps:
 ${dispatchIdentityGuard}      - uses: ${ACTION_CHECKOUT}
         with:
@@ -113,7 +121,7 @@ describe('release CI policy', () => {
     )
   })
 
-  it('rejects job names beyond the three stable required checks', () => {
+  it('rejects job names beyond the stable CI jobs', () => {
     const workflowWithExtraJob = `${compliantWorkflow}
   optional-smoke:
     name: Optional Smoke
@@ -122,7 +130,7 @@ describe('release CI policy', () => {
 `
 
     expect(validateReleaseCiPolicy(workflowWithExtraJob)).toContain(
-      'CI must expose exactly these required job names: Commit Policy, Typecheck & Lint, Unit & Component Tests.',
+      'CI must expose exactly these stable job names: Package Consumer Tools (Node ${{ matrix.node }}), Commit Policy, Typecheck & Lint, Unit & Component Tests.',
     )
   })
 
@@ -162,6 +170,52 @@ describe('release CI policy', () => {
 
     expect(validateReleaseCiPolicy(conditionallySkippedWorkflow)).toContain(
       'CI required jobs must run unconditionally for every configured trigger.',
+    )
+  })
+
+  it('rejects required job-level execution and privilege overrides', () => {
+    const weakenedWorkflow = compliantWorkflow.replace(
+      '  check:\n    name: Typecheck & Lint\n    runs-on: ubuntu-latest',
+      '  check:\n    name: Typecheck & Lint\n    runs-on: ubuntu-latest\n    continue-on-error: true\n    env:\n      NODE_OPTIONS: --import=attacker.js\n    permissions:\n      contents: write',
+    )
+
+    expect(validateReleaseCiPolicy(weakenedWorkflow)).toContain(
+      'CI job Typecheck & Lint must keep the exact blocking job contract: name, ubuntu-latest runner, and steps only.',
+    )
+  })
+
+  it('rejects quoted required job control keys', () => {
+    const weakenedWorkflow = compliantWorkflow.replace(
+      '  check:\n    name: Typecheck & Lint\n    runs-on: ubuntu-latest',
+      "  check:\n    name: Typecheck & Lint\n    runs-on: ubuntu-latest\n    'if': false\n    'env':\n      NODE_OPTIONS: --import=attacker.js",
+    )
+
+    expect(validateReleaseCiPolicy(weakenedWorkflow)).toContain(
+      'CI job Typecheck & Lint must keep the exact blocking job contract: name, ubuntu-latest runner, and steps only.',
+    )
+  })
+
+  it('rejects unnamed jobs outside the stable job set', () => {
+    const workflowWithUnnamedJob = `${compliantWorkflow}
+  unnamed-job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo bypass
+`
+
+    expect(validateReleaseCiPolicy(workflowWithUnnamedJob)).toContain(
+      'CI must expose exactly these stable job names: Package Consumer Tools (Node ${{ matrix.node }}), Commit Policy, Typecheck & Lint, Unit & Component Tests.',
+    )
+  })
+
+  it('rejects quoted job IDs outside the stable job set', () => {
+    const workflowWithQuotedJob = compliantWorkflow.replace(
+      'jobs:\n',
+      "jobs:\n  'attacker-job':\n    permissions:\n      contents: write\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo bypass\n",
+    )
+
+    expect(validateReleaseCiPolicy(workflowWithQuotedJob)).toContain(
+      'CI must expose exactly these stable job names: Package Consumer Tools (Node ${{ matrix.node }}), Commit Policy, Typecheck & Lint, Unit & Component Tests.',
     )
   })
 

--- a/scripts/__tests__/verify-windows-installer.unit.test.ts
+++ b/scripts/__tests__/verify-windows-installer.unit.test.ts
@@ -1,0 +1,41 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { verifyWindowsInstaller } from '../verify-windows-installer'
+
+describe('Windows installer verification', () => {
+  it('installs silently into an isolated directory and verifies the exact executable', async () => {
+    const runInstaller = vi.fn(async () => 0)
+    const verifyPath = vi.fn(async () => undefined)
+
+    await verifyWindowsInstaller(
+      {
+        installerPath: 'D:\\artifacts\\openwaggle.exe',
+        installDirectory: 'D:\\temp\\openwaggle-install',
+      },
+      { runInstaller, verifyPath },
+    )
+
+    expect(runInstaller).toHaveBeenCalledWith('D:\\artifacts\\openwaggle.exe', [
+      '/S',
+      '/D=D:\\temp\\openwaggle-install',
+    ])
+    expect(verifyPath).toHaveBeenNthCalledWith(1, 'D:\\artifacts\\openwaggle.exe')
+    expect(verifyPath).toHaveBeenNthCalledWith(
+      2,
+      join('D:\\temp\\openwaggle-install', 'OpenWaggle.exe'),
+    )
+  })
+
+  it('rejects a nonzero installer exit code before checking the executable', async () => {
+    const verifyPath = vi.fn(async () => undefined)
+
+    await expect(
+      verifyWindowsInstaller(
+        { installerPath: 'installer.exe', installDirectory: 'install' },
+        { runInstaller: async () => 1, verifyPath },
+      ),
+    ).rejects.toThrow('Windows installer exited with code 1')
+
+    expect(verifyPath).toHaveBeenCalledTimes(1)
+  })
+})

--- a/scripts/package-consumer-tools.ts
+++ b/scripts/package-consumer-tools.ts
@@ -1,0 +1,216 @@
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { access, appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, delimiter, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const OFFICIAL_NPM_REGISTRY = 'https://registry.npmjs.org/'
+const INSTALL_MODE = 'install'
+const VERIFY_MODE = 'verify'
+const MODE_ARGUMENT_INDEX = 2
+const FLAG_ARGUMENT_START_INDEX = 3
+const EXACT_PACK_RESULT_COUNT = 1
+const TOOL_ROOT_FLAG = '--tool-root'
+const GITHUB_PATH_FLAG = '--github-path'
+const PACKAGE_TOOLS = [
+  {
+    name: 'npm',
+    spec: 'npm@11.18.0',
+    version: '11.18.0',
+    integrity: 'sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==',
+  },
+  {
+    name: 'yarn',
+    spec: '@yarnpkg/cli-dist@4.17.1',
+    version: '4.17.1',
+    integrity: 'sha512-2tiSQuJNl/L3QwTdrq6lKWDpkcnp9MGvCT/rIldHcbu3SWfnLdmehvt3eulX1hT7FFt1Gjfq3CesF+kvhFip6g==',
+  },
+] as const
+const EXISTING_TOOLS = [
+  { name: 'pnpm', version: '11.6.0' },
+  { name: 'bun', version: '1.3.14' },
+] as const
+
+type CommandRunner = (command: string, args: readonly string[]) => Promise<string>
+
+type InstallInput = {
+  readonly toolRoot: string
+  readonly githubPath: string
+}
+
+type InstallDependencies = {
+  readonly runCommand?: CommandRunner
+  readonly appendSearchPath?: (filePath: string, contents: string) => Promise<void>
+  readonly prepareDirectory?: (directoryPath: string) => Promise<void>
+  readonly verifyDownloadedPackage?: (filePath: string, integrity: string) => Promise<void>
+  readonly writeUserConfig?: (filePath: string, contents: string) => Promise<void>
+}
+
+type VerifyDependencies = {
+  readonly runCommand?: CommandRunner
+  readonly resolveExecutable?: (name: string) => Promise<string | undefined>
+}
+
+function runCommand(command: string, args: readonly string[]) {
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8').on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.setEncoding('utf8').on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    child.once('error', reject)
+    child.once('exit', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim())
+        return
+      }
+      reject(new Error(`${command} ${args.join(' ')} exited with ${String(code)}: ${stderr.trim()}`))
+    })
+  })
+}
+
+async function resolveExecutable(name: string) {
+  const pathEntries = process.env['PATH']?.split(delimiter) ?? []
+  for (const pathEntry of pathEntries) {
+    const candidate = join(pathEntry, name)
+    try {
+      await access(candidate)
+      return candidate
+    } catch {
+      // Continue searching PATH.
+    }
+  }
+  return undefined
+}
+
+function packedTarballPath(packOutput: string, downloadDirectory: string) {
+  const parsed: unknown = JSON.parse(packOutput)
+  if (!Array.isArray(parsed) || parsed.length !== EXACT_PACK_RESULT_COUNT) {
+    throw new Error('npm pack must return exactly one package result.')
+  }
+  const results = parsed.map((item: unknown) => item)
+  const result = results[0]
+  if (typeof result !== 'object' || result === null) {
+    throw new Error('npm pack returned an invalid package result.')
+  }
+  const filename = 'filename' in result ? result.filename : undefined
+  if (typeof filename !== 'string' || filename.length === 0 || basename(filename) !== filename) {
+    throw new Error('npm pack returned an invalid tarball filename.')
+  }
+  return join(downloadDirectory, filename)
+}
+
+export async function verifyDownloadedPackageIntegrity(
+  filePath: string,
+  expectedIntegrity: string,
+) {
+  const digest = createHash('sha512').update(await readFile(filePath)).digest('base64')
+  const actualIntegrity = `sha512-${digest}`
+  if (actualIntegrity !== expectedIntegrity) {
+    throw new Error(`${basename(filePath)} integrity mismatch: ${actualIntegrity}`)
+  }
+}
+
+export async function installPackageConsumerTools(
+  input: InstallInput,
+  dependencies: InstallDependencies = {},
+) {
+  const execute = dependencies.runCommand ?? runCommand
+  const appendSearchPath = dependencies.appendSearchPath ?? appendFile
+  const prepareDirectory = dependencies.prepareDirectory ?? ((directoryPath) => mkdir(directoryPath, { recursive: true }))
+  const verifyDownloadedPackage = dependencies.verifyDownloadedPackage ?? verifyDownloadedPackageIntegrity
+  const writeUserConfig = dependencies.writeUserConfig ?? writeFile
+  const userConfigPath = join(input.toolRoot, 'empty.npmrc')
+  const downloadDirectory = join(input.toolRoot, 'downloads')
+  await prepareDirectory(input.toolRoot)
+  await prepareDirectory(downloadDirectory)
+  await writeUserConfig(userConfigPath, '')
+
+  const tarballPaths: string[] = []
+  for (const tool of PACKAGE_TOOLS) {
+    const packOutput = await execute('npm', [
+      'pack',
+      tool.spec,
+      '--json',
+      '--ignore-scripts',
+      `--pack-destination=${downloadDirectory}`,
+      `--registry=${OFFICIAL_NPM_REGISTRY}`,
+      `--userconfig=${userConfigPath}`,
+    ])
+    const tarballPath = packedTarballPath(packOutput, downloadDirectory)
+    await verifyDownloadedPackage(tarballPath, tool.integrity)
+    tarballPaths.push(tarballPath)
+  }
+
+  await execute('npm', [
+    'install',
+    '--global',
+    '--ignore-scripts',
+    `--prefix=${input.toolRoot}`,
+    `--registry=${OFFICIAL_NPM_REGISTRY}`,
+    `--userconfig=${userConfigPath}`,
+    ...tarballPaths,
+  ])
+  await appendSearchPath(input.githubPath, `${join(input.toolRoot, 'bin')}\n`)
+}
+
+export async function verifyPackageConsumerTools(
+  toolRoot: string,
+  dependencies: VerifyDependencies = {},
+) {
+  const execute = dependencies.runCommand ?? runCommand
+  const findExecutable = dependencies.resolveExecutable ?? resolveExecutable
+  for (const tool of [...PACKAGE_TOOLS, ...EXISTING_TOOLS]) {
+    const executable = await findExecutable(tool.name)
+    if (executable === undefined) throw new Error(`${tool.name} is not available on PATH.`)
+    if (tool.name === 'npm' || tool.name === 'yarn') {
+      const expectedExecutable = join(toolRoot, 'bin', tool.name)
+      if (executable !== expectedExecutable) {
+        throw new Error(`${tool.name} resolved from ${executable}, expected ${expectedExecutable}.`)
+      }
+    }
+    const actualVersion = await execute(executable, ['--version'])
+    if (actualVersion !== tool.version) {
+      throw new Error(`${tool.name} version mismatch: ${actualVersion} != ${tool.version}`)
+    }
+  }
+}
+
+function readFlag(args: readonly string[], flag: string) {
+  const index = args.indexOf(flag)
+  const value = index === -1 ? undefined : args[index + 1]
+  if (value === undefined || value.trim().length === 0) throw new Error(`Missing ${flag}.`)
+  return value
+}
+
+async function main() {
+  const mode = process.argv[MODE_ARGUMENT_INDEX]
+  const args = process.argv.slice(FLAG_ARGUMENT_START_INDEX)
+  const toolRoot = readFlag(args, TOOL_ROOT_FLAG)
+  if (mode === INSTALL_MODE) {
+    await installPackageConsumerTools({
+      toolRoot,
+      githubPath: readFlag(args, GITHUB_PATH_FLAG),
+    })
+    return
+  }
+  if (mode === VERIFY_MODE) {
+    await verifyPackageConsumerTools(toolRoot)
+    return
+  }
+  throw new Error(`Usage: package-consumer-tools.ts <${INSTALL_MODE}|${VERIFY_MODE}> ${TOOL_ROOT_FLAG} <path> [${GITHUB_PATH_FLAG} <path>]`)
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/scripts/package-release-validator-ci.ts
+++ b/scripts/package-release-validator-ci.ts
@@ -1,4 +1,5 @@
 import { parsePackageReleaseWorkflow } from './package-release-validator-workflow-structure'
+import { validateReleaseCiPolicy } from './release-ci-policy'
 import {
   jobExactNamedActionStepWithInputsIndex,
   jobExactNamedRunStepIndex,
@@ -82,11 +83,18 @@ function validateWorkflowExecutionContext(workflowRoot: unknown, violations: str
   )
 }
 
+function validateGeneralReleasePolicy(ciWorkflowText: string, violations: string[]) {
+  for (const violation of validateReleaseCiPolicy(ciWorkflowText)) {
+    violations.push(`${CI_WORKFLOW_PATH}: ${violation}`)
+  }
+}
+
 export function validateCiWorkflowText(ciWorkflowText: string, violations: string[]) {
   const workflow = parsePackageReleaseWorkflow(ciWorkflowText)
   for (const error of workflow.errors) {
     violations.push(`${CI_WORKFLOW_PATH} must contain valid YAML: ${error}`)
   }
+  validateGeneralReleasePolicy(ciWorkflowText, violations)
   validateWorkflowExecutionContext(workflow.root, violations)
   requireText(
     ciWorkflowText,

--- a/scripts/package-release-validator-ci.ts
+++ b/scripts/package-release-validator-ci.ts
@@ -1,0 +1,202 @@
+import { parsePackageReleaseWorkflow } from './package-release-validator-workflow-structure'
+import {
+  jobExactNamedActionStepWithInputsIndex,
+  jobExactNamedRunStepIndex,
+  workflowJobFailFast,
+  workflowJobHasOnlyKeys,
+  workflowJobHasExactSteps,
+  workflowJobMatrixHasOnlyKeys,
+  workflowJobMatrixValues,
+  workflowJobRunsOn,
+  workflowJobRunCommands,
+  workflowJobStrategyHasOnlyKeys,
+  workflowHasKey,
+  workflowMappingHasExactValues,
+} from './package-release-validator-workflow-steps'
+import type { WorkflowStepContract } from './package-release-validator-workflow-steps'
+
+const CI_WORKFLOW_PATH = '.github/workflows/ci.yml'
+const EXPECTED_NODE_VERSIONS = ['22.19.0', '24'] as const
+const INSTALL_CONSUMER_TOOLS_COMMAND =
+  'node scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"'
+const VERIFY_CONSUMER_TOOLS_COMMAND =
+  'node scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"'
+const EXPECTED_RUN_COMMANDS = [
+  INSTALL_CONSUMER_TOOLS_COMMAND,
+  VERIFY_CONSUMER_TOOLS_COMMAND,
+] as const
+const EXPECTED_CONSUMER_TOOL_STEPS = [
+  {
+    name: 'Checkout exact CI revision',
+    uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+    with: {
+      ref: "${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.sha }}",
+    },
+  },
+  {
+    name: 'Set up pinned pnpm',
+    uses: 'pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',
+    with: { version: '11.6.0' },
+  },
+  {
+    name: 'Set up matrix Node',
+    uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
+    with: { 'node-version': '${{ matrix.node }}' },
+  },
+  {
+    name: 'Set up pinned Bun',
+    uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+    with: { 'bun-version': '1.3.14' },
+  },
+  {
+    name: 'Install pinned package manager consumers',
+    run: INSTALL_CONSUMER_TOOLS_COMMAND,
+  },
+  {
+    name: 'Verify package manager consumer versions',
+    run: VERIFY_CONSUMER_TOOLS_COMMAND,
+  },
+] as const satisfies readonly WorkflowStepContract[]
+
+function addViolation(condition: boolean, message: string, violations: string[]) {
+  if (condition) violations.push(message)
+}
+
+function requireText(
+  source: string,
+  requirements: readonly (readonly [string, string])[],
+  violations: string[],
+) {
+  for (const [snippet, message] of requirements) {
+    addViolation(!source.includes(snippet), message, violations)
+  }
+}
+
+function validateWorkflowExecutionContext(workflowRoot: unknown, violations: string[]) {
+  addViolation(
+    !workflowMappingHasExactValues(workflowRoot, 'env', {
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true,
+    }) || workflowHasKey(workflowRoot, 'defaults'),
+    `${CI_WORKFLOW_PATH} must keep its exact workflow-level execution environment and omit workflow defaults.`,
+    violations,
+  )
+}
+
+export function validateCiWorkflowText(ciWorkflowText: string, violations: string[]) {
+  const workflow = parsePackageReleaseWorkflow(ciWorkflowText)
+  for (const error of workflow.errors) {
+    violations.push(`${CI_WORKFLOW_PATH} must contain valid YAML: ${error}`)
+  }
+  validateWorkflowExecutionContext(workflow.root, violations)
+  requireText(
+    ciWorkflowText,
+    [
+      ['workflow_dispatch:', `${CI_WORKFLOW_PATH} must accept release PR CI dispatches.`],
+      [
+        'head_sha:',
+        `${CI_WORKFLOW_PATH} must accept the exact release PR head SHA as input head_sha.`,
+      ],
+      ['DISPATCHED_SHA: ${{ github.sha }}', `${CI_WORKFLOW_PATH} must read the dispatched SHA.`],
+      [
+        'EXPECTED_SHA: ${{ inputs.head_sha }}',
+        `${CI_WORKFLOW_PATH} must read the expected release PR SHA.`,
+      ],
+      [
+        'test "$DISPATCHED_SHA" = "$EXPECTED_SHA"',
+        `${CI_WORKFLOW_PATH} must fail closed when the dispatched branch moved from the release PR SHA.`,
+      ],
+    ],
+    violations,
+  )
+  const matrixNodes = workflowJobMatrixValues(workflow.root, 'package-consumer-tools', 'node')
+  addViolation(
+    matrixNodes.length !== EXPECTED_NODE_VERSIONS.length ||
+      matrixNodes.some((version, index) => version !== EXPECTED_NODE_VERSIONS[index]),
+    `${CI_WORKFLOW_PATH} package-consumer-tools must test exactly Node 22.19.0 and Node 24.`,
+    violations,
+  )
+  addViolation(
+    !workflowJobHasOnlyKeys(workflow.root, 'package-consumer-tools', [
+      'name',
+      'runs-on',
+      'strategy',
+      'steps',
+    ]) ||
+      workflowJobRunsOn(workflow.root, 'package-consumer-tools') !== 'ubuntu-latest' ||
+      workflowJobFailFast(workflow.root, 'package-consumer-tools') !== false ||
+      !workflowJobStrategyHasOnlyKeys(workflow.root, 'package-consumer-tools', [
+        'fail-fast',
+        'matrix',
+      ]) ||
+      !workflowJobMatrixHasOnlyKeys(workflow.root, 'package-consumer-tools', ['node']),
+    `${CI_WORKFLOW_PATH} package-consumer-tools must keep its exact blocking job contract.`,
+    violations,
+  )
+  addViolation(
+    !workflowJobHasExactSteps(
+      workflow.root,
+      'package-consumer-tools',
+      EXPECTED_CONSUMER_TOOL_STEPS,
+    ),
+    `${CI_WORKFLOW_PATH} package-consumer-tools must contain exactly its approved pinned setup, install, and verification steps in order.`,
+    violations,
+  )
+  const stepIndexes = [
+    jobExactNamedActionStepWithInputsIndex(
+      workflow.root,
+      'package-consumer-tools',
+      'Checkout exact CI revision',
+      'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+      { ref: "${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.sha }}" },
+    ),
+    jobExactNamedActionStepWithInputsIndex(
+      workflow.root,
+      'package-consumer-tools',
+      'Set up pinned pnpm',
+      'pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',
+      { version: '11.6.0' },
+    ),
+    jobExactNamedActionStepWithInputsIndex(
+      workflow.root,
+      'package-consumer-tools',
+      'Set up matrix Node',
+      'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
+      { 'node-version': '${{ matrix.node }}' },
+    ),
+    jobExactNamedActionStepWithInputsIndex(
+      workflow.root,
+      'package-consumer-tools',
+      'Set up pinned Bun',
+      'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+      { 'bun-version': '1.3.14' },
+    ),
+    jobExactNamedRunStepIndex(
+      workflow.root,
+      'package-consumer-tools',
+      'Install pinned package manager consumers',
+      'node scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"',
+    ),
+    jobExactNamedRunStepIndex(
+      workflow.root,
+      'package-consumer-tools',
+      'Verify package manager consumer versions',
+      'node scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"',
+    ),
+  ]
+  addViolation(
+    stepIndexes.some((index) => index < 0) ||
+      stepIndexes.some(
+        (index, position) =>
+          position > 0 && index <= (stepIndexes[position - 1] ?? Number.NEGATIVE_INFINITY),
+      ),
+    `${CI_WORKFLOW_PATH} package-consumer-tools must execute its exact pinned setup, install, and verification steps in order.`,
+    violations,
+  )
+  const runCommands = workflowJobRunCommands(workflow.root, 'package-consumer-tools')
+  addViolation(
+    runCommands.length !== EXPECTED_RUN_COMMANDS.length ||
+      runCommands.some((command, index) => command !== EXPECTED_RUN_COMMANDS[index]),
+    `${CI_WORKFLOW_PATH} package-consumer-tools must execute only its exact typed install and verification commands.`,
+    violations,
+  )
+}

--- a/scripts/package-release-validator-consumers.ts
+++ b/scripts/package-release-validator-consumers.ts
@@ -1,0 +1,248 @@
+import { runsExactCommand } from './package-release-validator-workflow-structure'
+import {
+  jobExactNamedActionStepWithInputsIndex,
+  jobExactNamedRunStepIndex,
+  jobHasDedicatedExactRunStep,
+  jobHasDedicatedExactRunStepWithEnv,
+  workflowJobCondition,
+  workflowJobFailFast,
+  workflowJobHasOnlyKeys,
+  workflowJobHasExactSteps,
+  workflowJobMatrixHasOnlyKeys,
+  workflowJobMatrixValues,
+  workflowJobNeeds,
+  workflowJobRunsOn,
+  workflowJobRunCommands,
+  workflowJobStrategyHasOnlyKeys,
+  workflowHasKey,
+} from './package-release-validator-workflow-steps'
+import type { WorkflowStepContract } from './package-release-validator-workflow-steps'
+
+const JOB_INDENT_WIDTH = 2
+const WORKFLOW_PATH = '.github/workflows/package-release.yml'
+const EXPECTED_NODE_VERSIONS = ['22.19.0', '24'] as const
+const EXPECTED_RELEASE_QA_NEEDS = ['release-plan'] as const
+const INSTALL_CONSUMER_TOOLS_COMMAND =
+  'node .release-tooling/scripts/package-consumer-tools.ts install --tool-root "$RUNNER_TEMP/package-managers" --github-path "$GITHUB_PATH"'
+const VERIFY_CONSUMER_TOOLS_COMMAND =
+  'node .release-tooling/scripts/package-consumer-tools.ts verify --tool-root "$RUNNER_TEMP/package-managers"'
+const EXPECTED_RUN_COMMANDS = [
+  'pnpm install --frozen-lockfile',
+  INSTALL_CONSUMER_TOOLS_COMMAND,
+  VERIFY_CONSUMER_TOOLS_COMMAND,
+  'pnpm check',
+  'pnpm exec playwright install chromium',
+  'pnpm build:packages && pnpm package:smoke',
+] as const
+const EXPECTED_RELEASE_QA_STEPS = [
+  {
+    uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+    with: { ref: '${{ needs.release-plan.outputs.source_sha }}' },
+  },
+  {
+    name: 'Checkout immutable package consumer tooling',
+    uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+    with: {
+      ref: '${{ github.workflow_sha }}',
+      path: '.release-tooling',
+      'sparse-checkout': 'scripts/package-consumer-tools.ts',
+      'sparse-checkout-cone-mode': false,
+    },
+  },
+  {
+    uses: 'pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',
+    with: { version: '11.6.0' },
+  },
+  {
+    uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
+    with: { 'node-version': '${{ matrix.node }}', cache: 'pnpm' },
+  },
+  {
+    uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+    with: { 'bun-version': '1.3.14' },
+  },
+  { run: 'pnpm install --frozen-lockfile' },
+  { name: 'Install pinned package manager consumers', run: INSTALL_CONSUMER_TOOLS_COMMAND },
+  { name: 'Verify package manager consumer versions', run: VERIFY_CONSUMER_TOOLS_COMMAND },
+  {
+    name: 'Run full release checks on Node 24',
+    if: '${{ matrix.node == 24 }}',
+    run: 'pnpm check',
+  },
+  {
+    name: 'Install Chromium for package browser smoke',
+    run: 'pnpm exec playwright install chromium',
+  },
+  {
+    name: 'Smoke packed consumers',
+    env: {
+      OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1',
+      OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun',
+    },
+    run: 'pnpm build:packages && pnpm package:smoke',
+  },
+] as const satisfies readonly WorkflowStepContract[]
+
+function addViolation(condition: boolean, message: string, violations: string[]) {
+  if (condition) violations.push(message)
+}
+
+function workflowJobBlock(workflowText: string, jobName: string) {
+  const marker = `  ${jobName}:\n`
+  const start = workflowText.indexOf(marker)
+  if (start === -1) return ''
+  const remainder = workflowText.slice(start + marker.length)
+  const nextJob = remainder.search(
+    new RegExp(`^ {${JOB_INDENT_WIDTH}}[a-zA-Z0-9_-]+:\\s*$`, 'm'),
+  )
+  return nextJob === -1 ? remainder : remainder.slice(0, nextJob)
+}
+
+function validateReleaseQaJobContract(workflowRoot: unknown, violations: string[]) {
+  const matrixNodes = workflowJobMatrixValues(workflowRoot, 'release-qa', 'node')
+  const jobNeeds = workflowJobNeeds(workflowRoot, 'release-qa')
+  addViolation(
+    workflowHasKey(workflowRoot, 'env') || workflowHasKey(workflowRoot, 'defaults'),
+    `${WORKFLOW_PATH} must omit workflow-level environment and defaults from package publishing.`,
+    violations,
+  )
+  addViolation(
+    matrixNodes.length !== EXPECTED_NODE_VERSIONS.length ||
+      matrixNodes.some((version, index) => version !== EXPECTED_NODE_VERSIONS[index]),
+    `${WORKFLOW_PATH} release-qa must smoke consumers on Node 22.19.0 and Node 24.`,
+    violations,
+  )
+  addViolation(
+    !workflowJobHasOnlyKeys(workflowRoot, 'release-qa', [
+      'name',
+      'needs',
+      'if',
+      'runs-on',
+      'strategy',
+      'steps',
+    ]) ||
+      workflowJobCondition(workflowRoot, 'release-qa') !==
+        "${{ always() && needs.release-plan.result == 'success' }}" ||
+      jobNeeds.length !== EXPECTED_RELEASE_QA_NEEDS.length ||
+      jobNeeds.some((need, index) => need !== EXPECTED_RELEASE_QA_NEEDS[index]) ||
+      workflowJobRunsOn(workflowRoot, 'release-qa') !== 'ubuntu-latest' ||
+      workflowJobFailFast(workflowRoot, 'release-qa') !== false ||
+      !workflowJobStrategyHasOnlyKeys(workflowRoot, 'release-qa', ['fail-fast', 'matrix']) ||
+      !workflowJobMatrixHasOnlyKeys(workflowRoot, 'release-qa', ['node']),
+    `${WORKFLOW_PATH} release-qa must keep its exact blocking QA job contract.`,
+    violations,
+  )
+}
+
+function validateConsumerToolingSteps(workflowRoot: unknown, violations: string[]) {
+  addViolation(
+    !workflowJobHasExactSteps(workflowRoot, 'release-qa', EXPECTED_RELEASE_QA_STEPS),
+    `${WORKFLOW_PATH} release-qa must execute exactly its approved source checkout, immutable tooling setup, and QA steps in order.`,
+    violations,
+  )
+  const installIndex = jobExactNamedRunStepIndex(
+    workflowRoot,
+    'release-qa',
+    'Install pinned package manager consumers',
+    INSTALL_CONSUMER_TOOLS_COMMAND,
+  )
+  const verifyIndex = jobExactNamedRunStepIndex(
+    workflowRoot,
+    'release-qa',
+    'Verify package manager consumer versions',
+    VERIFY_CONSUMER_TOOLS_COMMAND,
+  )
+  addViolation(
+    installIndex < 0,
+    `${WORKFLOW_PATH} release-qa must install npm and Yarn in an isolated runner path.`,
+    violations,
+  )
+  addViolation(
+    verifyIndex < 0,
+    `${WORKFLOW_PATH} release-qa must verify isolated npm and Yarn executable paths.`,
+    violations,
+  )
+  const runCommands = workflowJobRunCommands(workflowRoot, 'release-qa')
+  addViolation(
+    runCommands.length !== EXPECTED_RUN_COMMANDS.length ||
+      runCommands.some((command, index) => command !== EXPECTED_RUN_COMMANDS[index]),
+    `${WORKFLOW_PATH} release-qa must install package consumer tools only through the typed integrity-pinned installer.`,
+    violations,
+  )
+  const checkoutIndex = jobExactNamedActionStepWithInputsIndex(
+    workflowRoot,
+    'release-qa',
+    'Checkout immutable package consumer tooling',
+    'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+    {
+      ref: '${{ github.workflow_sha }}',
+      path: '.release-tooling',
+      'sparse-checkout': 'scripts/package-consumer-tools.ts',
+      'sparse-checkout-cone-mode': false,
+    },
+  )
+  addViolation(
+    checkoutIndex < 0,
+    `${WORKFLOW_PATH} release-qa must checkout immutable package consumer tooling from the workflow commit.`,
+    violations,
+  )
+  addViolation(
+    checkoutIndex < 0 || installIndex <= checkoutIndex || verifyIndex <= installIndex,
+    `${WORKFLOW_PATH} release-qa must checkout tooling before installing and verifying package consumers.`,
+    violations,
+  )
+}
+
+export function validateWorkflowConsumerSmoke(
+  workflowRoot: unknown,
+  workflowText: string,
+  violations: string[],
+) {
+  const job = workflowJobBlock(workflowText, 'release-qa')
+  validateReleaseQaJobContract(workflowRoot, violations)
+  validateConsumerToolingSteps(workflowRoot, violations)
+  addViolation(
+    !runsExactCommand(job, 'pnpm build:packages && pnpm package:smoke'),
+    `${WORKFLOW_PATH} release-qa must smoke exact packed consumers on every Node matrix entry.`,
+    violations,
+  )
+  addViolation(
+    !job.includes('version: 11.6.0'),
+    `${WORKFLOW_PATH} release-qa must pin pnpm 11.6.0.`,
+    violations,
+  )
+  addViolation(
+    !job.includes('bun-version: 1.3.14'),
+    `${WORKFLOW_PATH} release-qa must install Bun 1.3.14.`,
+    violations,
+  )
+  const browserInstall = jobHasDedicatedExactRunStep(
+    workflowRoot,
+    'release-qa',
+    'pnpm exec playwright install chromium',
+  )
+  addViolation(
+    !browserInstall,
+    `${WORKFLOW_PATH} release-qa must install Chromium with pinned project Playwright tooling.`,
+    violations,
+  )
+  const browserSmoke = jobHasDedicatedExactRunStepWithEnv(
+    workflowRoot,
+    'release-qa',
+    'pnpm build:packages && pnpm package:smoke',
+    {
+      OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1',
+      OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun',
+    },
+  )
+  addViolation(
+    !browserSmoke,
+    `${WORKFLOW_PATH} release-qa must run browser-enabled package smoke on every Node matrix entry.`,
+    violations,
+  )
+  addViolation(
+    !job.includes("OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'"),
+    `${WORKFLOW_PATH} release-qa must require npm, pnpm, Yarn, and Bun package consumers.`,
+    violations,
+  )
+}

--- a/scripts/package-release-validator-workflow-steps.ts
+++ b/scripts/package-release-validator-workflow-steps.ts
@@ -1,11 +1,20 @@
 import { isMap, isScalar, isSeq } from 'yaml'
 
+const EXACT_NAMED_ACTION_STEP_KEY_COUNT = 3
+
 function mapValue(node: unknown, key: string) {
   if (!isMap(node)) return undefined
   for (const pair of node.items) {
     if (isScalar(pair.key) && pair.key.value === key) return pair.value
   }
   return undefined
+}
+
+function mapKeys(node: unknown) {
+  if (!isMap(node)) return []
+  return node.items.flatMap((pair) =>
+    isScalar(pair.key) && typeof pair.key.value === 'string' ? [pair.key.value] : [],
+  )
 }
 
 function workflowJobSteps(workflowRoot: unknown, jobName: string) {
@@ -17,11 +26,55 @@ function scalarString(node: unknown): string | undefined {
   return isScalar(node) && typeof node.value === 'string' ? node.value : undefined
 }
 
+type WorkflowStepScalar = string | number | boolean
+
+export type WorkflowStepContract = Readonly<
+  Record<string, WorkflowStepScalar | Readonly<Record<string, WorkflowStepScalar>>>
+>
+
+function scalarValue(node: unknown): WorkflowStepScalar | undefined {
+  return isScalar(node) &&
+    (typeof node.value === 'string' ||
+      typeof node.value === 'number' ||
+      typeof node.value === 'boolean')
+    ? node.value
+    : undefined
+}
+
+function hasOnlyKeys(node: unknown, allowedKeys: readonly string[]) {
+  const actualKeys = mapKeys(node)
+  return actualKeys.length === allowedKeys.length && actualKeys.every((key) => allowedKeys.includes(key))
+}
+
+function matchesExactMapping(node: unknown, expected: WorkflowStepContract): boolean {
+  const expectedKeys = Object.keys(expected)
+  if (!hasOnlyKeys(node, expectedKeys)) return false
+  return expectedKeys.every((key) => {
+    const expectedValue = expected[key]
+    const actualValue = mapValue(node, key)
+    return typeof expectedValue === 'object'
+      ? matchesExactMapping(actualValue, expectedValue)
+      : scalarValue(actualValue) === expectedValue
+  })
+}
+
 export function workflowJobCondition(
   workflowRoot: unknown,
   jobName: string,
 ): string | undefined {
   return scalarString(mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'if'))
+}
+
+export function workflowHasKey(workflowRoot: unknown, key: string) {
+  return mapKeys(workflowRoot).includes(key)
+}
+
+export function workflowMappingHasExactValues(
+  workflowRoot: unknown,
+  mappingName: string,
+  expected: WorkflowStepContract,
+) {
+  return matchesExactMapping(mapValue(workflowRoot, mappingName), expected)
 }
 
 export function workflowJobNeeds(workflowRoot: unknown, jobName: string): readonly string[] {
@@ -44,12 +97,87 @@ export function workflowJobRunCommands(
   })
 }
 
-function isDedicatedExactRunStep(step: unknown, command: string) {
-  const run = mapValue(step, 'run')
+export function workflowJobHasExactSteps(
+  workflowRoot: unknown,
+  jobName: string,
+  expectedSteps: readonly WorkflowStepContract[],
+) {
+  const actualSteps = workflowJobSteps(workflowRoot, jobName)
   return (
-    isScalar(run) &&
-    run.value === command &&
-    !['continue-on-error', 'shell', 'if'].some((key) => mapValue(step, key) !== undefined)
+    actualSteps.length === expectedSteps.length &&
+    actualSteps.every((step, index) => matchesExactMapping(step, expectedSteps[index] ?? {}))
+  )
+}
+
+export function workflowJobMatrixValues(
+  workflowRoot: unknown,
+  jobName: string,
+  matrixName: string,
+): readonly string[] {
+  const matrix = mapValue(
+    mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'strategy'),
+    'matrix',
+  )
+  const values = mapValue(matrix, matrixName)
+  if (!isSeq(values)) return []
+  return values.items.flatMap((item) => {
+    if (!isScalar(item)) return []
+    return typeof item.value === 'string' || typeof item.value === 'number'
+      ? [String(item.value)]
+      : []
+  })
+}
+
+export function workflowJobRunsOn(workflowRoot: unknown, jobName: string) {
+  return scalarString(mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'runs-on'))
+}
+
+export function workflowJobFailFast(workflowRoot: unknown, jobName: string) {
+  const failFast = mapValue(
+    mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'strategy'),
+    'fail-fast',
+  )
+  return isScalar(failFast) && typeof failFast.value === 'boolean' ? failFast.value : undefined
+}
+
+export function workflowJobHasOnlyKeys(
+  workflowRoot: unknown,
+  jobName: string,
+  expectedKeys: readonly string[],
+) {
+  return hasOnlyKeys(mapValue(mapValue(workflowRoot, 'jobs'), jobName), expectedKeys)
+}
+
+export function workflowJobStrategyHasOnlyKeys(
+  workflowRoot: unknown,
+  jobName: string,
+  expectedKeys: readonly string[],
+) {
+  const strategy = mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'strategy')
+  return hasOnlyKeys(strategy, expectedKeys)
+}
+
+export function workflowJobMatrixHasOnlyKeys(
+  workflowRoot: unknown,
+  jobName: string,
+  expectedKeys: readonly string[],
+) {
+  const matrix = mapValue(
+    mapValue(mapValue(mapValue(workflowRoot, 'jobs'), jobName), 'strategy'),
+    'matrix',
+  )
+  return hasOnlyKeys(matrix, expectedKeys)
+}
+
+function hasExactRunCommand(step: unknown, command: string) {
+  const run = mapValue(step, 'run')
+  return isScalar(run) && run.value === command
+}
+
+function isDedicatedExactRunStep(step: unknown, command: string) {
+  return (
+    hasExactRunCommand(step, command) &&
+    mapKeys(step).every((key) => key === 'name' || key === 'run')
   )
 }
 
@@ -63,19 +191,76 @@ export function jobHasDedicatedExactRunStep(
   )
 }
 
+export function jobHasDedicatedExactNamedRunStep(
+  workflowRoot: unknown,
+  jobName: string,
+  stepName: string,
+  command: string,
+) {
+  return jobExactNamedRunStepIndex(workflowRoot, jobName, stepName, command) >= 0
+}
+
+export function jobExactNamedRunStepIndex(
+  workflowRoot: unknown,
+  jobName: string,
+  stepName: string,
+  command: string,
+) {
+  return workflowJobSteps(workflowRoot, jobName).findIndex(
+    (step) =>
+      scalarString(mapValue(step, 'name')) === stepName &&
+      hasExactRunCommand(step, command) &&
+      hasOnlyKeys(step, ['name', 'run']),
+  )
+}
+
+export function jobHasExactNamedActionStepWithInputs(
+  workflowRoot: unknown,
+  jobName: string,
+  stepName: string,
+  action: string,
+  expectedInputs: Readonly<Record<string, string | boolean>>,
+) {
+  return jobExactNamedActionStepWithInputsIndex(
+    workflowRoot,
+    jobName,
+    stepName,
+    action,
+    expectedInputs,
+  ) >= 0
+}
+
+export function jobExactNamedActionStepWithInputsIndex(
+  workflowRoot: unknown,
+  jobName: string,
+  stepName: string,
+  action: string,
+  expectedInputs: Readonly<Record<string, string | boolean>>,
+) {
+  return workflowJobSteps(workflowRoot, jobName).findIndex((step) => {
+    const inputs = mapValue(step, 'with')
+    const expectedInputKeys = Object.keys(expectedInputs)
+    return (
+      scalarString(mapValue(step, 'name')) === stepName &&
+      scalarString(mapValue(step, 'uses')) === action &&
+      mapKeys(step).length === EXACT_NAMED_ACTION_STEP_KEY_COUNT &&
+      mapKeys(inputs).length === expectedInputKeys.length &&
+      expectedInputKeys.every((key) => scalarValue(mapValue(inputs, key)) === expectedInputs[key])
+    )
+  })
+}
+
 export function jobHasDedicatedExactRunStepWithEnv(
   workflowRoot: unknown,
   jobName: string,
   command: string,
-  envName: string,
-  envValue: string,
+  expectedEnv: Readonly<Record<string, WorkflowStepScalar>>,
 ) {
   return workflowJobSteps(workflowRoot, jobName).some((step) => {
-    const actualEnvValue = mapValue(mapValue(step, 'env'), envName)
     return (
-      isDedicatedExactRunStep(step, command) &&
-      isScalar(actualEnvValue) &&
-      actualEnvValue.value === envValue
+      hasExactRunCommand(step, command) &&
+      hasOnlyKeys(step, ['name', 'env', 'run']) &&
+      matchesExactMapping(mapValue(step, 'env'), expectedEnv)
     )
   })
 }

--- a/scripts/package-release-validator.ts
+++ b/scripts/package-release-validator.ts
@@ -5,16 +5,16 @@ import {
   executableWorkflowText,
   parsePackageReleaseWorkflow,
   runsCommandFragment,
-  runsExactCommand,
   workflowActionUses,
   workflowRunCommands,
   validatePublicationBoundary,
 } from './package-release-validator-workflow-structure'
 import {
   jobHasDedicatedExactRunStep,
-  jobHasDedicatedExactRunStepWithEnv,
 } from './package-release-validator-workflow-steps'
 import { validateWorkflowRecovery } from './package-release-validator-recovery'
+import { validateWorkflowConsumerSmoke } from './package-release-validator-consumers'
+import { validateCiWorkflowText } from './package-release-validator-ci'
 
 type JsonObject = { readonly [key: string]: unknown }
 interface ExpectedPackage { readonly component: string; readonly dependency?: string; readonly name: string; readonly path: string }
@@ -185,25 +185,6 @@ function validateWorkflowPermissions(workflowText: string, violations: string[])
   }
 }
 
-function validateWorkflowConsumerSmoke(workflowRoot: unknown, workflowText: string, violations: string[]) {
-  const job = workflowJobBlock(workflowText, 'release-qa')
-  addViolation(!job.includes('- 22.19.0') || !job.includes('- 24'), `${WORKFLOW_PATH} release-qa must smoke consumers on Node 22.19.0 and Node 24.`, violations)
-  const exactCommands = [
-    ['npm install --global npm@11.18.0', `${WORKFLOW_PATH} release-qa must pin npm 11.18.0.`], ['corepack install --global yarn@4.17.1', `${WORKFLOW_PATH} release-qa must install Yarn 4.17.1.`],
-    ['test "$(npm --version)" = "11.18.0"', `${WORKFLOW_PATH} release-qa must verify npm 11.18.0 before smoke testing.`], ['test "$(pnpm --version)" = "11.6.0"', `${WORKFLOW_PATH} release-qa must verify pnpm 11.6.0 before smoke testing.`],
-    ['test "$(cd "$RUNNER_TEMP" && yarn --version)" = "4.17.1"', `${WORKFLOW_PATH} release-qa must verify Yarn 4.17.1 outside the pnpm workspace before smoke testing.`], ['test "$(bun --version)" = "1.3.14"', `${WORKFLOW_PATH} release-qa must verify Bun 1.3.14 before smoke testing.`],
-    ['pnpm build:packages && pnpm package:smoke', `${WORKFLOW_PATH} release-qa must smoke exact packed consumers on every Node matrix entry.`],
-  ] as const
-  for (const [command, message] of exactCommands) addViolation(!runsExactCommand(job, command), message, violations)
-  addViolation(!job.includes('version: 11.6.0'), `${WORKFLOW_PATH} release-qa must pin pnpm 11.6.0.`, violations)
-  addViolation(!job.includes('bun-version: 1.3.14'), `${WORKFLOW_PATH} release-qa must install Bun 1.3.14.`, violations)
-  const browserInstall = jobHasDedicatedExactRunStep(workflowRoot, 'release-qa', 'pnpm exec playwright install chromium')
-  addViolation(!browserInstall, `${WORKFLOW_PATH} release-qa must install Chromium with pinned project Playwright tooling.`, violations)
-  const browserSmoke = jobHasDedicatedExactRunStepWithEnv(workflowRoot, 'release-qa', 'pnpm build:packages && pnpm package:smoke', 'OPENWAGGLE_PACKAGE_BROWSER_SMOKE', '1')
-  addViolation(!browserSmoke, `${WORKFLOW_PATH} release-qa must run browser-enabled package smoke on every Node matrix entry.`, violations)
-  addViolation(!job.includes("OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'"), `${WORKFLOW_PATH} release-qa must require npm, pnpm, Yarn, and Bun package consumers.`, violations)
-}
-
 function validateWorkflowPathsAndDispatch(workflowText: string, violations: string[]) {
   for (const expected of EXPECTED_PACKAGES) {
     addViolation(!workflowText.includes(`${expected.path}/**`), `${WORKFLOW_PATH} must scope push releases to ${expected.path}/**.`, violations)
@@ -278,15 +259,8 @@ function validateWorkflowText(workflowText: string, violations: string[]) {
   validateWorkflowPathsAndDispatch(executableText, violations); validateWorkflowPublication(workflow.root, executableText, violations)
   validateWorkflowRecovery(workflow.root, executableText, violations)
   for (const command of ['pnpm package-release:validate', 'pnpm check', 'pnpm build:packages']) addViolation(!jobHasDedicatedExactRunStep(workflow.root, 'validate-dry-run', command), `${WORKFLOW_PATH} must execute ${command}.`, violations)
-  const snippets = ['workflow_dispatch:', 'package_tag:', "inputs.package_tag == ''", "inputs.package_tag != ''", `config-file: ${CONFIG_PATH}`, `manifest-file: ${MANIFEST_PATH}`, 'id-token: write', 'environment: npm', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'ACTIONS_ID_TOKEN_REQUEST_URL', 'npm install --global npm@11.18.0', 'node scripts/package-release-publish.ts "$TARBALL"', 'node-version: 24.14.0', 'test "$(npm --version)" = "11.9.0"', 'paths_released', "matrix.released == 'true'", 'fail-fast: false', 'tar -xOf "$TARBALL" package/package.json', 'npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version', 'npm view "$DEPENDENCY_NAME@$DEPENDENCY_VERSION" version', 'pnpm package-release:validate', 'pnpm check', 'pnpm build:packages', "github.event_name == 'push'", "github.ref == 'refs/heads/main'", 'group: package-release', 'cancel-in-progress: false']
+  const snippets = ['workflow_dispatch:', 'package_tag:', "inputs.package_tag == ''", "inputs.package_tag != ''", `config-file: ${CONFIG_PATH}`, `manifest-file: ${MANIFEST_PATH}`, 'id-token: write', 'environment: npm', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'ACTIONS_ID_TOKEN_REQUEST_URL', 'package-consumer-tools.ts install', 'node scripts/package-release-publish.ts "$TARBALL"', 'node-version: 24.14.0', 'test "$(npm --version)" = "11.9.0"', 'paths_released', "matrix.released == 'true'", 'fail-fast: false', 'tar -xOf "$TARBALL" package/package.json', 'npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version', 'npm view "$DEPENDENCY_NAME@$DEPENDENCY_VERSION" version', 'pnpm package-release:validate', 'pnpm check', 'pnpm build:packages', "github.event_name == 'push'", "github.ref == 'refs/heads/main'", 'group: package-release', 'cancel-in-progress: false']
   requireText(executableText, snippets.map((snippet) => [snippet, `${WORKFLOW_PATH} must contain ${snippet}.`]), violations)
-}
-
-function validateCiWorkflowText(ciWorkflowText: string, violations: string[]) {
-  requireText(ciWorkflowText, [
-    ['workflow_dispatch:', `${CI_WORKFLOW_PATH} must accept release PR CI dispatches.`], ['head_sha:', `${CI_WORKFLOW_PATH} must accept the exact release PR head SHA as input head_sha.`],
-    ['DISPATCHED_SHA: ${{ github.sha }}', `${CI_WORKFLOW_PATH} must read the dispatched SHA.`], ['EXPECTED_SHA: ${{ inputs.head_sha }}', `${CI_WORKFLOW_PATH} must read the expected release PR SHA.`], ['test "$DISPATCHED_SHA" = "$EXPECTED_SHA"', `${CI_WORKFLOW_PATH} must fail closed when the dispatched branch moved from the release PR SHA.`],
-  ], violations)
 }
 
 async function validateTextFile(projectRoot: string, filePath: string, validate: (text: string, violations: string[]) => void, violations: string[]) {

--- a/scripts/release-ci-policy-workflow.ts
+++ b/scripts/release-ci-policy-workflow.ts
@@ -1,0 +1,68 @@
+import { isMap, isScalar, parseDocument } from 'yaml'
+
+export interface ReleaseCiWorkflowJob {
+  readonly block: string
+  readonly keys: readonly string[]
+  readonly name: string
+}
+
+function mapValue(node: unknown, key: string) {
+  if (!isMap(node)) return undefined
+  for (const pair of node.items) {
+    if (isScalar(pair.key) && pair.key.value === key) return pair.value
+  }
+  return undefined
+}
+
+function scalarString(node: unknown): string | undefined {
+  return isScalar(node) && typeof node.value === 'string' ? node.value : undefined
+}
+
+function mapKeys(node: unknown) {
+  if (!isMap(node)) return []
+  return node.items.flatMap((pair) => {
+    const key = scalarString(pair.key)
+    return key === undefined ? [] : [key]
+  })
+}
+
+function readTextJobBlocks(workflow: string) {
+  const jobsMarker = 'jobs:\n'
+  const jobsStart = workflow.indexOf(jobsMarker)
+  if (jobsStart === -1) return new Map<string, string>()
+
+  const jobsSection = workflow.slice(jobsStart + jobsMarker.length)
+  const jobStarts = [...jobsSection.matchAll(/^ {2}([A-Za-z0-9_-]+):\s*$/gm)].flatMap(
+    (match) =>
+      match.index === undefined || match[1] === undefined
+        ? []
+        : [{ id: match[1], index: match.index }],
+  )
+
+  return new Map(
+    jobStarts.map(({ id, index: start }, position) => [
+      id,
+      jobsSection.slice(start, jobStarts[position + 1]?.index ?? jobsSection.length).trimEnd(),
+    ]),
+  )
+}
+
+export function readReleaseCiWorkflowJobs(workflow: string) {
+  const document = parseDocument(workflow)
+  if (document.errors.length > 0) return []
+  const jobs = mapValue(document.contents, 'jobs')
+  if (!isMap(jobs)) return []
+  const textBlocks = readTextJobBlocks(workflow)
+
+  return jobs.items.flatMap((pair) => {
+    const id = scalarString(pair.key)
+    if (id === undefined) return []
+    return [
+      {
+        block: textBlocks.get(id) ?? '',
+        keys: mapKeys(pair.value),
+        name: scalarString(mapValue(pair.value, 'name')) ?? '',
+      } satisfies ReleaseCiWorkflowJob,
+    ]
+  })
+}

--- a/scripts/release-ci-policy.ts
+++ b/scripts/release-ci-policy.ts
@@ -1,19 +1,21 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
+import {
+  readReleaseCiWorkflowJobs,
+  type ReleaseCiWorkflowJob,
+} from './release-ci-policy-workflow'
 
 export const REQUIRED_CI_CHECKS = [
   'Commit Policy',
   'Typecheck & Lint',
   'Unit & Component Tests',
 ] as const
-
-interface WorkflowJob {
-  readonly block: string
-  readonly name: string
-}
+const PACKAGE_CONSUMER_CI_JOB = 'Package Consumer Tools (Node ${{ matrix.node }})'
+const EXPECTED_CI_JOBS = [PACKAGE_CONSUMER_CI_JOB, ...REQUIRED_CI_CHECKS] as const
 
 const CI_WORKFLOW_PATH = '.github/workflows/ci.yml'
 const CONCURRENCY_POLICY_FIELD_COUNT = 2
+const REQUIRED_JOB_KEYS = ['name', 'runs-on', 'steps'] as const
 const ACTION_CHECKOUT = 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6'
 const ACTION_SETUP_NODE = 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6'
 const PNPM_ACTION_SETUP = 'pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4'
@@ -90,25 +92,11 @@ function hasMainBranchTrigger(workflow: string, trigger: string) {
   return new RegExp(`^ {2}${trigger}:\\s*\\n {4}branches: \\[main\\]$`, 'm').test(workflow)
 }
 
-function readJobs(workflow: string) {
-  const jobsMarker = 'jobs:\n'
-  const jobsStart = workflow.indexOf(jobsMarker)
-  if (jobsStart === -1) return []
-
-  const jobsSection = workflow.slice(jobsStart + jobsMarker.length)
-  const jobStarts = [...jobsSection.matchAll(/^ {2}[A-Za-z0-9_-]+:\s*$/gm)].flatMap((match) =>
-    match.index === undefined ? [] : [match.index],
-  )
-
-  return jobStarts.flatMap((start, index) => {
-    const block = jobsSection.slice(start, jobStarts[index + 1] ?? jobsSection.length).trimEnd()
-    const name = /^ {4}name: (.+)$/m.exec(block)?.[1]
-
-    return name === undefined ? [] : [{ block, name } satisfies WorkflowJob]
-  })
+function readJobKeys(job: ReleaseCiWorkflowJob) {
+  return job.keys
 }
 
-function readSteps(job: WorkflowJob) {
+function readSteps(job: ReleaseCiWorkflowJob) {
   const starts = [...job.block.matchAll(/^ {6}- /gm)].flatMap((match) =>
     match.index === undefined ? [] : [match.index],
   )
@@ -144,7 +132,11 @@ function validateTriggers(workflow: string, violations: string[]) {
   }
 }
 
-function validateDispatchSupport(workflow: string, jobs: readonly WorkflowJob[], violations: string[]) {
+function validateDispatchSupport(
+  workflow: string,
+  jobs: readonly ReleaseCiWorkflowJob[],
+  violations: string[],
+) {
   const dispatchInput = /^ {2}workflow_dispatch:\s*\n {4}inputs:\s*\n {6}head_sha:\s*\n(?: {8}.+\n)*? {8}required: true\s*\n {8}type: string$/m
   if (!dispatchInput.test(workflow)) {
     violations.push('CI must accept a required workflow_dispatch head_sha input.')
@@ -200,7 +192,11 @@ function validateConcurrency(workflow: string, violations: string[]) {
   }
 }
 
-function validateSecurity(workflow: string, jobs: readonly WorkflowJob[], violations: string[]) {
+function validateSecurity(
+  workflow: string,
+  jobs: readonly ReleaseCiWorkflowJob[],
+  violations: string[],
+) {
   const permissions = readTopLevelSection(workflow, 'permissions')
   if (permissions.length !== 1 || permissions[0] !== 'contents: read') {
     violations.push('CI must grant only read access to repository contents.')
@@ -230,14 +226,32 @@ function validateSecurity(workflow: string, jobs: readonly WorkflowJob[], violat
   }
 }
 
-function validateRequiredChecks(workflow: string, jobs: readonly WorkflowJob[], violations: string[]) {
+function validateRequiredJobContract(job: ReleaseCiWorkflowJob, violations: string[]) {
+  if (!isRequiredCheck(job.name)) return
+  const jobKeys = readJobKeys(job)
+  const hasExactJobContract =
+    jobKeys.length === REQUIRED_JOB_KEYS.length &&
+    REQUIRED_JOB_KEYS.every((key) => jobKeys.includes(key)) &&
+    /^ {4}runs-on: ubuntu-latest$/m.test(job.block)
+  if (!hasExactJobContract) {
+    violations.push(
+      `CI job ${job.name} must keep the exact blocking job contract: name, ubuntu-latest runner, and steps only.`,
+    )
+  }
+}
+
+function validateRequiredChecks(
+  workflow: string,
+  jobs: readonly ReleaseCiWorkflowJob[],
+  violations: string[],
+) {
   const jobNames = jobs.map((job) => job.name)
   if (
-    jobNames.length !== REQUIRED_CI_CHECKS.length ||
-    REQUIRED_CI_CHECKS.some((checkName) => !jobNames.includes(checkName))
+    jobNames.length !== EXPECTED_CI_JOBS.length ||
+    EXPECTED_CI_JOBS.some((checkName) => !jobNames.includes(checkName))
   ) {
     violations.push(
-      `CI must expose exactly these required job names: ${REQUIRED_CI_CHECKS.join(', ')}.`,
+      `CI must expose exactly these stable job names: ${EXPECTED_CI_JOBS.join(', ')}.`,
     )
   }
   if (/^ {4}if:/m.test(workflow)) {
@@ -251,6 +265,7 @@ function validateRequiredChecks(workflow: string, jobs: readonly WorkflowJob[], 
   }
 
   for (const job of jobs) {
+    validateRequiredJobContract(job, violations)
     const expected = EXPECTED_STEPS.get(job.name)
     if (expected === undefined) continue
     const actual = readSteps(job)
@@ -276,7 +291,7 @@ function validateRequiredChecks(workflow: string, jobs: readonly WorkflowJob[], 
 
 export function validateReleaseCiPolicy(workflow: string) {
   const violations: string[] = []
-  const jobs = readJobs(workflow)
+  const jobs = readReleaseCiWorkflowJobs(workflow)
 
   validateTriggers(workflow, violations)
   validateDispatchSupport(workflow, jobs, violations)

--- a/scripts/verify-windows-installer.ts
+++ b/scripts/verify-windows-installer.ts
@@ -1,0 +1,62 @@
+import { spawn } from 'node:child_process'
+import { access, mkdtemp } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { pathToFileURL } from 'node:url'
+
+const INSTALLER_ARGUMENT_INDEX = 2
+const INSTALLED_EXECUTABLE = 'OpenWaggle.exe'
+const SILENT_INSTALL_ARGUMENT = '/S'
+
+type VerifyWindowsInstallerInput = {
+  readonly installerPath: string
+  readonly installDirectory: string
+}
+
+type VerifyWindowsInstallerDependencies = {
+  readonly runInstaller?: (installerPath: string, args: readonly string[]) => Promise<number | null>
+  readonly verifyPath?: (filePath: string) => Promise<void>
+}
+
+function runInstaller(installerPath: string, args: readonly string[]) {
+  return new Promise<number | null>((resolve, reject) => {
+    const child = spawn(installerPath, args, { stdio: 'inherit' })
+    child.once('error', reject)
+    child.once('exit', resolve)
+  })
+}
+
+export async function verifyWindowsInstaller(
+  input: VerifyWindowsInstallerInput,
+  dependencies: VerifyWindowsInstallerDependencies = {},
+) {
+  const verifyPath = dependencies.verifyPath ?? access
+  const executeInstaller = dependencies.runInstaller ?? runInstaller
+  await verifyPath(input.installerPath)
+
+  const exitCode = await executeInstaller(input.installerPath, [
+    SILENT_INSTALL_ARGUMENT,
+    `/D=${input.installDirectory}`,
+  ])
+  if (exitCode !== 0) {
+    throw new Error(`Windows installer exited with code ${String(exitCode)}.`)
+  }
+
+  await verifyPath(join(input.installDirectory, INSTALLED_EXECUTABLE))
+}
+
+async function main() {
+  const installerPath = process.argv[INSTALLER_ARGUMENT_INDEX]
+  if (installerPath === undefined || installerPath.trim().length === 0) {
+    throw new Error('Usage: verify-windows-installer.ts <installer-path>')
+  }
+  const installDirectory = await mkdtemp(join(tmpdir(), 'openwaggle-install-'))
+  await verifyWindowsInstaller({ installerPath, installDirectory })
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary
- bootstrap exact npm/Yarn consumer tools from integrity-pinned tarballs on Node 22.19 and 24
- make recovery QA use immutable workflow tooling while testing the exact release source SHA
- validate complete fail-closed CI/release QA contracts against injection and skipped checks
- verify Windows NSIS installers through a deterministic destination and explicit exit status

## Validation
- `pnpm check`
- `pnpm test` (1,884 unit; 100 integration; 485 component tests)
- focused release suite (38 tests)
- three independent read-only reviews; final pass found no P0-P3 issues
