### PR TITLE
fix(release): support lockfile-free Yarn recovery smoke

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -497,6 +497,7 @@ jobs:
         env:
           OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1'
           OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
         run: pnpm build:packages && pnpm package:smoke
 
   prepare-artifacts:

--- a/scripts/__tests__/package-release-validator-consumers.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-consumers.unit.test.ts
@@ -198,6 +198,25 @@ describe('package release consumer tool validation', () => {
     }
   })
 
+  it('rejects recovery smoke that allows Yarn CI immutable installs', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+    try {
+      const invalidWorkflow = validWorkflow.replace(
+        "          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'\n",
+        '',
+      )
+      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
+
+      const result = await validatePackageReleaseFiles(projectRoot)
+
+      expect(result.violations).toContain(
+        '.github/workflows/package-release.yml release-qa must disable Yarn immutable installs for lockfile-free packed consumers.',
+      )
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
   it('rejects CI without the exact Node 22.19 and Node 24 consumer-tool matrix', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
     try {

--- a/scripts/package-release-validator-consumers.ts
+++ b/scripts/package-release-validator-consumers.ts
@@ -34,6 +34,11 @@ const EXPECTED_RUN_COMMANDS = [
   'pnpm exec playwright install chromium',
   'pnpm build:packages && pnpm package:smoke',
 ] as const
+const EXPECTED_SMOKE_ENV = {
+  OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1',
+  OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun',
+  YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+} as const
 const EXPECTED_RELEASE_QA_STEPS = [
   {
     uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
@@ -75,10 +80,7 @@ const EXPECTED_RELEASE_QA_STEPS = [
   },
   {
     name: 'Smoke packed consumers',
-    env: {
-      OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1',
-      OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun',
-    },
+    env: EXPECTED_SMOKE_ENV,
     run: 'pnpm build:packages && pnpm package:smoke',
   },
 ] as const satisfies readonly WorkflowStepContract[]
@@ -230,10 +232,7 @@ export function validateWorkflowConsumerSmoke(
     workflowRoot,
     'release-qa',
     'pnpm build:packages && pnpm package:smoke',
-    {
-      OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1',
-      OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun',
-    },
+    EXPECTED_SMOKE_ENV,
   )
   addViolation(
     !browserSmoke,
@@ -243,6 +242,11 @@ export function validateWorkflowConsumerSmoke(
   addViolation(
     !job.includes("OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'"),
     `${WORKFLOW_PATH} release-qa must require npm, pnpm, Yarn, and Bun package consumers.`,
+    violations,
+  )
+  addViolation(
+    !job.includes("YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'"),
+    `${WORKFLOW_PATH} release-qa must disable Yarn immutable installs for lockfile-free packed consumers.`,
     violations,
   )
 }


### PR DESCRIPTION
## Summary
- disable Yarn CI immutable installs only for lockfile-free packed-consumer smoke
- enforce the exact recovery smoke environment in release policy validation
- add a regression test for immutable recovery tags

## Diagnosis
Recovery QA checks out the immutable `0.1.0` package tag. Its historical smoke script invokes Yarn 4.17.1 without `--no-immutable`, so GitHub CI rejects creation of the consumer lockfile with `YN0028` before package validation.

## QA
- `pnpm check`
- `pnpm test:unit` (332 files, 1,889 tests)
- targeted package release validator tests (12 tests)
- exact Yarn 4.17.1 minimized CI reproduction: fails without override, passes with override
- independent read-only review: no P0-P3 findings
