### PR TITLE
fix(release): cover Yarn smoke in full recovery checks

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -488,6 +488,8 @@ jobs:
 
       - name: Run full release checks on Node 24
         if: ${{ matrix.node == 24 }}
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
         run: pnpm check
 
       - name: Install Chromium for package browser smoke

--- a/scripts/__tests__/package-release-validator-consumers.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-consumers.unit.test.ts
@@ -198,25 +198,6 @@ describe('package release consumer tool validation', () => {
     }
   })
 
-  it('rejects recovery smoke that allows Yarn CI immutable installs', async () => {
-    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
-    try {
-      const invalidWorkflow = validWorkflow.replace(
-        "          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'\n",
-        '',
-      )
-      await writeMinimalPackageReleaseProject(projectRoot, invalidWorkflow)
-
-      const result = await validatePackageReleaseFiles(projectRoot)
-
-      expect(result.violations).toContain(
-        '.github/workflows/package-release.yml release-qa must disable Yarn immutable installs for lockfile-free packed consumers.',
-      )
-    } finally {
-      await fs.rm(projectRoot, { recursive: true, force: true })
-    }
-  })
-
   it('rejects CI without the exact Node 22.19 and Node 24 consumer-tool matrix', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
     try {

--- a/scripts/__tests__/package-release-validator-yarn-recovery.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-yarn-recovery.unit.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { validatePackageReleaseFiles } from '../package-release-validator'
+import {
+  validWorkflow,
+  writeMinimalPackageReleaseProject,
+} from './package-release-validator.fixtures'
+
+async function validateWorkflowWithout(workflowFragment: string, replacement: string) {
+  const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+  try {
+    await writeMinimalPackageReleaseProject(
+      projectRoot,
+      validWorkflow.replace(workflowFragment, replacement),
+    )
+    return await validatePackageReleaseFiles(projectRoot)
+  } finally {
+    await fs.rm(projectRoot, { recursive: true, force: true })
+  }
+}
+
+describe('package release Yarn recovery validation', () => {
+  it('rejects recovery smoke that allows Yarn CI immutable installs', async () => {
+    const result = await validateWorkflowWithout(
+      "          OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'\n          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'",
+      "          OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'",
+    )
+
+    expect(result.violations).toContain(
+      '.github/workflows/package-release.yml release-qa must disable Yarn immutable installs for lockfile-free packed consumers.',
+    )
+  })
+
+  it('rejects full release checks that allow Yarn CI immutable installs', async () => {
+    const result = await validateWorkflowWithout(
+      "        env:\n          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'\n        run: pnpm check",
+      '        run: pnpm check',
+    )
+
+    expect(result.violations).toContain(
+      '.github/workflows/package-release.yml release-qa full checks must disable Yarn immutable installs for lockfile-free packed consumers.',
+    )
+  })
+})

--- a/scripts/package-release-validator-consumers.ts
+++ b/scripts/package-release-validator-consumers.ts
@@ -2,6 +2,7 @@ import { runsExactCommand } from './package-release-validator-workflow-structure
 import {
   jobExactNamedActionStepWithInputsIndex,
   jobExactNamedRunStepIndex,
+  jobHasConditionalExactRunStepWithEnv,
   jobHasDedicatedExactRunStep,
   jobHasDedicatedExactRunStepWithEnv,
   workflowJobCondition,
@@ -34,10 +35,13 @@ const EXPECTED_RUN_COMMANDS = [
   'pnpm exec playwright install chromium',
   'pnpm build:packages && pnpm package:smoke',
 ] as const
+const EXPECTED_YARN_LOCKFILE_FREE_ENV = {
+  YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+} as const
 const EXPECTED_SMOKE_ENV = {
   OPENWAGGLE_PACKAGE_BROWSER_SMOKE: '1',
   OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun',
-  YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+  ...EXPECTED_YARN_LOCKFILE_FREE_ENV,
 } as const
 const EXPECTED_RELEASE_QA_STEPS = [
   {
@@ -72,6 +76,7 @@ const EXPECTED_RELEASE_QA_STEPS = [
   {
     name: 'Run full release checks on Node 24',
     if: '${{ matrix.node == 24 }}',
+    env: EXPECTED_YARN_LOCKFILE_FREE_ENV,
     run: 'pnpm check',
   },
   {
@@ -228,6 +233,18 @@ export function validateWorkflowConsumerSmoke(
     `${WORKFLOW_PATH} release-qa must install Chromium with pinned project Playwright tooling.`,
     violations,
   )
+  const fullReleaseChecks = jobHasConditionalExactRunStepWithEnv(
+    workflowRoot,
+    'release-qa',
+    'pnpm check',
+    '${{ matrix.node == 24 }}',
+    EXPECTED_YARN_LOCKFILE_FREE_ENV,
+  )
+  addViolation(
+    !fullReleaseChecks,
+    `${WORKFLOW_PATH} release-qa full checks must disable Yarn immutable installs for lockfile-free packed consumers.`,
+    violations,
+  )
   const browserSmoke = jobHasDedicatedExactRunStepWithEnv(
     workflowRoot,
     'release-qa',
@@ -240,13 +257,13 @@ export function validateWorkflowConsumerSmoke(
     violations,
   )
   addViolation(
-    !job.includes("OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'"),
-    `${WORKFLOW_PATH} release-qa must require npm, pnpm, Yarn, and Bun package consumers.`,
+    !browserSmoke,
+    `${WORKFLOW_PATH} release-qa must disable Yarn immutable installs for lockfile-free packed consumers.`,
     violations,
   )
   addViolation(
-    !job.includes("YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'"),
-    `${WORKFLOW_PATH} release-qa must disable Yarn immutable installs for lockfile-free packed consumers.`,
+    !job.includes("OPENWAGGLE_PACKAGE_SMOKE_REQUIRED_MANAGERS: 'npm,pnpm,yarn,bun'"),
+    `${WORKFLOW_PATH} release-qa must require npm, pnpm, Yarn, and Bun package consumers.`,
     violations,
   )
 }

--- a/scripts/package-release-validator-workflow-steps.ts
+++ b/scripts/package-release-validator-workflow-steps.ts
@@ -264,3 +264,20 @@ export function jobHasDedicatedExactRunStepWithEnv(
     )
   })
 }
+
+export function jobHasConditionalExactRunStepWithEnv(
+  workflowRoot: unknown,
+  jobName: string,
+  command: string,
+  condition: string,
+  expectedEnv: Readonly<Record<string, WorkflowStepScalar>>,
+) {
+  return workflowJobSteps(workflowRoot, jobName).some((step) => {
+    return (
+      hasExactRunCommand(step, command) &&
+      scalarString(mapValue(step, 'if')) === condition &&
+      hasOnlyKeys(step, ['name', 'if', 'env', 'run']) &&
+      matchesExactMapping(mapValue(step, 'env'), expectedEnv)
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- apply the lockfile-free Yarn recovery override to the Node 24 full release check, which itself runs package smoke
- enforce the exact conditional step environment in release policy validation
- split focused Yarn recovery regressions into a dedicated test file

## Diagnosis
Recovery run 29397319043 proved the explicit packed-consumer step green on Node 22.19. Node 24 then failed earlier because `pnpm check` also runs package smoke from the immutable tag without a lockfile. Both entry points now carry the same step-local override; publication jobs remain unaffected.

## QA
- `pnpm check`
- focused validator tests (26 tests)
- exact Yarn 4.17.1 CI reproduction
- independent read-only review: no P0-P3 findings
