### PR TITLE
fix(release): verify pull request attestation identity

### DIFF
--- a/scripts/__tests__/package-release-promote.unit.test.ts
+++ b/scripts/__tests__/package-release-promote.unit.test.ts
@@ -5,10 +5,13 @@ import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
-  assertPackageReleaseAttestationIdentity,
-  packageReleaseAttestationVerificationArgs,
   releaseAssetRepairPlan,
 } from '../package-release-artifact-contract'
+import {
+  assertPackageReleaseAttestationSourceCommit,
+  assertPackageReleaseAttestationIdentity,
+  packageReleaseAttestationVerificationArgs,
+} from '../package-release-provenance'
 import {
   promoteVerifiedPackageRelease,
   readPackageReleasePlan,
@@ -135,7 +138,6 @@ describe('package release promotion', () => {
       packageReleaseAttestationVerificationArgs(
         '/artifacts/package.tgz',
         'OpenWaggle/OpenWaggle',
-        'release-head',
       ),
     ).toEqual([
       'attestation',
@@ -145,8 +147,6 @@ describe('package release promotion', () => {
       'OpenWaggle/OpenWaggle',
       '--signer-workflow',
       'OpenWaggle/OpenWaggle/.github/workflows/ci.yml',
-      '--source-digest',
-      'release-head',
       '--deny-self-hosted-runners',
       '--format',
       'json',
@@ -165,16 +165,66 @@ describe('package release promotion', () => {
       },
     }]
 
-    expect(() => assertPackageReleaseAttestationIdentity(verified, {
+    expect(assertPackageReleaseAttestationIdentity(verified, {
       repository: 'OpenWaggle/OpenWaggle',
       runId: '123',
-      sourceSha: 'release-head',
-    })).not.toThrow()
+    })).toBe('release-head')
     expect(() => assertPackageReleaseAttestationIdentity(verified, {
       repository: 'OpenWaggle/OpenWaggle',
       runId: '124',
-      sourceSha: 'release-head',
     })).toThrow('selected CI run')
+
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }, { sha: 'release-head' }],
+        sha: 'pull-request-merge-sha',
+        tree: { sha: 'source-tree' },
+      },
+      {
+        attestationSourceSha: 'pull-request-merge-sha',
+        candidateSourceSha: 'release-head',
+        sourceTree: 'source-tree',
+      },
+    )).not.toThrow()
+
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }],
+        sha: 'release-head',
+        tree: { sha: 'source-tree' },
+      },
+      {
+        attestationSourceSha: 'release-head',
+        candidateSourceSha: 'release-head',
+        sourceTree: 'source-tree',
+      },
+    )).not.toThrow()
+
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }, { sha: 'different-head' }],
+        sha: 'pull-request-merge-sha',
+        tree: { sha: 'source-tree' },
+      },
+      {
+        attestationSourceSha: 'pull-request-merge-sha',
+        candidateSourceSha: 'release-head',
+        sourceTree: 'source-tree',
+      },
+    )).toThrow('candidate head and source tree')
+
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }, { sha: 'release-head' }],
+        sha: 'pull-request-merge-sha',
+        tree: { sha: 'different-tree' },
+      },
+      {
+        attestationSourceSha: 'pull-request-merge-sha',
+        candidateSourceSha: 'release-head',
+        sourceTree: 'source-tree',
+      },
+    )).toThrow('candidate head and source tree')
   })
 
   it('rejects a base-only promotion plan loaded from disk', async () => {

--- a/scripts/__tests__/package-release-promote.unit.test.ts
+++ b/scripts/__tests__/package-release-promote.unit.test.ts
@@ -8,11 +8,6 @@ import {
   releaseAssetRepairPlan,
 } from '../package-release-artifact-contract'
 import {
-  assertPackageReleaseAttestationSourceCommit,
-  assertPackageReleaseAttestationIdentity,
-  packageReleaseAttestationVerificationArgs,
-} from '../package-release-provenance'
-import {
   promoteVerifiedPackageRelease,
   readPackageReleasePlan,
   verifyPackageReleasePublicationEnvironment,
@@ -131,100 +126,6 @@ describe('package release promotion', () => {
         sha: 'workflow-definition-sha',
       }),
     ).toThrow('does not match the triggering main commit')
-  })
-
-  it('binds provenance to the CI signer workflow and selected source run', () => {
-    expect(
-      packageReleaseAttestationVerificationArgs(
-        '/artifacts/package.tgz',
-        'OpenWaggle/OpenWaggle',
-      ),
-    ).toEqual([
-      'attestation',
-      'verify',
-      '/artifacts/package.tgz',
-      '--repo',
-      'OpenWaggle/OpenWaggle',
-      '--signer-workflow',
-      'OpenWaggle/OpenWaggle/.github/workflows/ci.yml',
-      '--deny-self-hosted-runners',
-      '--format',
-      'json',
-    ])
-
-    const verified = [{
-      verificationResult: {
-        signature: {
-          certificate: {
-            buildConfigURI: 'https://github.com/OpenWaggle/OpenWaggle/.github/workflows/ci.yml@refs/pull/135/merge',
-            runInvocationURI: 'https://github.com/OpenWaggle/OpenWaggle/actions/runs/123/attempts/2',
-            runnerEnvironment: 'github-hosted',
-            sourceRepositoryDigest: 'release-head',
-          },
-        },
-      },
-    }]
-
-    expect(assertPackageReleaseAttestationIdentity(verified, {
-      repository: 'OpenWaggle/OpenWaggle',
-      runId: '123',
-    })).toBe('release-head')
-    expect(() => assertPackageReleaseAttestationIdentity(verified, {
-      repository: 'OpenWaggle/OpenWaggle',
-      runId: '124',
-    })).toThrow('selected CI run')
-
-    expect(() => assertPackageReleaseAttestationSourceCommit(
-      {
-        parents: [{ sha: 'base-sha' }, { sha: 'release-head' }],
-        sha: 'pull-request-merge-sha',
-        tree: { sha: 'source-tree' },
-      },
-      {
-        attestationSourceSha: 'pull-request-merge-sha',
-        candidateSourceSha: 'release-head',
-        sourceTree: 'source-tree',
-      },
-    )).not.toThrow()
-
-    expect(() => assertPackageReleaseAttestationSourceCommit(
-      {
-        parents: [{ sha: 'base-sha' }],
-        sha: 'release-head',
-        tree: { sha: 'source-tree' },
-      },
-      {
-        attestationSourceSha: 'release-head',
-        candidateSourceSha: 'release-head',
-        sourceTree: 'source-tree',
-      },
-    )).not.toThrow()
-
-    expect(() => assertPackageReleaseAttestationSourceCommit(
-      {
-        parents: [{ sha: 'base-sha' }, { sha: 'different-head' }],
-        sha: 'pull-request-merge-sha',
-        tree: { sha: 'source-tree' },
-      },
-      {
-        attestationSourceSha: 'pull-request-merge-sha',
-        candidateSourceSha: 'release-head',
-        sourceTree: 'source-tree',
-      },
-    )).toThrow('candidate head and source tree')
-
-    expect(() => assertPackageReleaseAttestationSourceCommit(
-      {
-        parents: [{ sha: 'base-sha' }, { sha: 'release-head' }],
-        sha: 'pull-request-merge-sha',
-        tree: { sha: 'different-tree' },
-      },
-      {
-        attestationSourceSha: 'pull-request-merge-sha',
-        candidateSourceSha: 'release-head',
-        sourceTree: 'source-tree',
-      },
-    )).toThrow('candidate head and source tree')
   })
 
   it('rejects a base-only promotion plan loaded from disk', async () => {

--- a/scripts/__tests__/package-release-provenance.unit.test.ts
+++ b/scripts/__tests__/package-release-provenance.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertPackageReleaseAttestationIdentity,
+  assertPackageReleaseAttestationSourceCommit,
+  packageReleaseAttestationVerificationArgs,
+} from '../package-release-provenance'
+
+const PULL_REQUEST_SOURCE_IDENTITY = {
+  attestationSourceSha: 'pull-request-merge-sha',
+  candidateSourceSha: 'release-head',
+  sourceTree: 'source-tree',
+} as const
+
+describe('package release provenance', () => {
+  it('binds verification to the CI signer workflow and selected run', () => {
+    expect(
+      packageReleaseAttestationVerificationArgs(
+        '/artifacts/package.tgz',
+        'OpenWaggle/OpenWaggle',
+      ),
+    ).toEqual([
+      'attestation',
+      'verify',
+      '/artifacts/package.tgz',
+      '--repo',
+      'OpenWaggle/OpenWaggle',
+      '--signer-workflow',
+      'OpenWaggle/OpenWaggle/.github/workflows/ci.yml',
+      '--deny-self-hosted-runners',
+      '--format',
+      'json',
+    ])
+
+    const verified = [{
+      verificationResult: {
+        signature: {
+          certificate: {
+            buildConfigURI: 'https://github.com/OpenWaggle/OpenWaggle/.github/workflows/ci.yml@refs/pull/135/merge',
+            runInvocationURI: 'https://github.com/OpenWaggle/OpenWaggle/actions/runs/123/attempts/2',
+            runnerEnvironment: 'github-hosted',
+            sourceRepositoryDigest: 'release-head',
+          },
+        },
+      },
+    }]
+
+    expect(assertPackageReleaseAttestationIdentity(verified, {
+      repository: 'OpenWaggle/OpenWaggle',
+      runId: '123',
+    })).toBe('release-head')
+    expect(() => assertPackageReleaseAttestationIdentity(verified, {
+      repository: 'OpenWaggle/OpenWaggle',
+      runId: '124',
+    })).toThrow('selected CI run')
+  })
+
+  it('accepts the exact pull-request merge commit and direct candidate commit', () => {
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }, { sha: 'release-head' }],
+        sha: 'pull-request-merge-sha',
+        tree: { sha: 'source-tree' },
+      },
+      PULL_REQUEST_SOURCE_IDENTITY,
+    )).not.toThrow()
+
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }],
+        sha: 'release-head',
+        tree: { sha: 'source-tree' },
+      },
+      {
+        attestationSourceSha: 'release-head',
+        candidateSourceSha: 'release-head',
+        sourceTree: 'source-tree',
+      },
+    )).not.toThrow()
+  })
+
+  it('rejects a merge without the candidate parent or exact source tree', () => {
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }, { sha: 'different-head' }],
+        sha: 'pull-request-merge-sha',
+        tree: { sha: 'source-tree' },
+      },
+      PULL_REQUEST_SOURCE_IDENTITY,
+    )).toThrow('candidate head and source tree')
+
+    expect(() => assertPackageReleaseAttestationSourceCommit(
+      {
+        parents: [{ sha: 'base-sha' }, { sha: 'release-head' }],
+        sha: 'pull-request-merge-sha',
+        tree: { sha: 'different-tree' },
+      },
+      PULL_REQUEST_SOURCE_IDENTITY,
+    )).toThrow('candidate head and source tree')
+  })
+})

--- a/scripts/__tests__/package-release-validator-security.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-security.unit.test.ts
@@ -80,7 +80,7 @@ describe('package release workflow security validation', () => {
   })
 
   it('rejects candidate-head digest assumptions for pull-request attestations', async () => {
-    const invalidSource = `${validProvenanceSource}\nconst forbidden = '--source-digest'\n`
+    const invalidSource = `${validProvenanceSource}\nconst forbidden = "--source-digest"\n`
     const result = await validateProvenance(invalidSource)
 
     expect(result.violations).toContain(

--- a/scripts/__tests__/package-release-validator-security.unit.test.ts
+++ b/scripts/__tests__/package-release-validator-security.unit.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { validatePackageReleaseFiles } from '../package-release-validator'
 import {
+  validProvenanceSource,
   validWorkflow,
   writeMinimalPackageReleaseProject,
 } from './package-release-validator.fixtures'
@@ -15,6 +16,20 @@ async function validateWorkflow(workflow: string) {
   const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
   temporaryDirectories.push(projectRoot)
   await writeMinimalPackageReleaseProject(projectRoot, workflow)
+  return validatePackageReleaseFiles(projectRoot)
+}
+
+async function validateProvenance(provenanceSource: string) {
+  const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openwaggle-package-release-'))
+  temporaryDirectories.push(projectRoot)
+  await writeMinimalPackageReleaseProject(
+    projectRoot,
+    validWorkflow,
+    '0.1.0',
+    'released',
+    undefined,
+    provenanceSource,
+  )
   return validatePackageReleaseFiles(projectRoot)
 }
 
@@ -62,6 +77,15 @@ describe('package release workflow security validation', () => {
       '.github/workflows/package-release.yml must download from the exact successful CI run.',
       '.github/workflows/package-release.yml must bind artifact provenance to its PR head SHA.',
     ]))
+  })
+
+  it('rejects candidate-head digest assumptions for pull-request attestations', async () => {
+    const invalidSource = `${validProvenanceSource}\nconst forbidden = '--source-digest'\n`
+    const result = await validateProvenance(invalidSource)
+
+    expect(result.violations).toContain(
+      'package-release-provenance.ts must not assume a pull-request attestation uses the candidate head digest.',
+    )
   })
 
   it.each([

--- a/scripts/__tests__/package-release-validator.fixtures.ts
+++ b/scripts/__tests__/package-release-validator.fixtures.ts
@@ -58,6 +58,11 @@ const validContextSource = readFileSync(
   'utf8',
 )
 
+export const validProvenanceSource = readFileSync(
+  path.join(process.cwd(), 'scripts/package-release-provenance.ts'),
+  'utf8',
+)
+
 async function writeFile(filePath: string, contents: string) {
   await fs.mkdir(path.dirname(filePath), { recursive: true })
   await fs.writeFile(filePath, contents, 'utf8')
@@ -73,6 +78,7 @@ export async function writeMinimalPackageReleaseProject(
   version = '0.1.0',
   manifestState: 'released' | 'bootstrap' = 'released',
   ciWorkflowText = validCiWorkflow,
+  provenanceSource = validProvenanceSource,
 ) {
   await writeJson(path.join(projectRoot, 'release-please-config.json'), {
     'release-type': 'node',
@@ -135,6 +141,7 @@ export async function writeMinimalPackageReleaseProject(
   await writeFile(path.join(projectRoot, 'scripts/package-release-artifact-contract.ts'), validArtifactContractSource)
   await writeFile(path.join(projectRoot, 'scripts/package-release-artifact-locator.ts'), validLocatorSource)
   await writeFile(path.join(projectRoot, 'scripts/package-release-context.ts'), validContextSource)
+  await writeFile(path.join(projectRoot, 'scripts/package-release-provenance.ts'), provenanceSource)
 
   for (const [index, packageDirectory] of packageDirectories.entries()) {
     const dependencies =

--- a/scripts/package-release-artifact-contract.ts
+++ b/scripts/package-release-artifact-contract.ts
@@ -24,58 +24,8 @@ export interface PackageReleaseArtifactManifest {
   readonly sourceTree: string
 }
 
-export interface PackageReleaseAttestationIdentity {
-  readonly repository: string
-  readonly runId: string
-  readonly sourceSha: string
-}
-
 function isJsonObject(value: unknown): value is { readonly [key: string]: unknown } {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-export function packageReleaseAttestationVerificationArgs(
-  file: string,
-  repository: string,
-  sourceSha: string,
-) {
-  return [
-    'attestation', 'verify', file,
-    '--repo', repository,
-    '--signer-workflow', `${repository}/.github/workflows/ci.yml`,
-    '--source-digest', sourceSha,
-    '--deny-self-hosted-runners',
-    '--format', 'json',
-  ]
-}
-
-export function assertPackageReleaseAttestationIdentity(
-  value: unknown,
-  identity: PackageReleaseAttestationIdentity,
-) {
-  const expectedWorkflowPrefix =
-    `https://github.com/${identity.repository}/.github/workflows/ci.yml@`
-  const expectedRunPrefix =
-    `https://github.com/${identity.repository}/actions/runs/${identity.runId}/attempts/`
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error('Artifact attestation verification returned no identity result.')
-  }
-  const hasSelectedIdentity = value.some((entry) => {
-    if (!isJsonObject(entry) || !isJsonObject(entry.verificationResult) ||
-      !isJsonObject(entry.verificationResult.signature) ||
-      !isJsonObject(entry.verificationResult.signature.certificate)) return false
-    const certificate = entry.verificationResult.signature.certificate
-    return typeof certificate.buildConfigURI === 'string' &&
-      certificate.buildConfigURI.startsWith(expectedWorkflowPrefix) &&
-      typeof certificate.runInvocationURI === 'string' &&
-      certificate.runInvocationURI.startsWith(expectedRunPrefix) &&
-      /^\d+$/.test(certificate.runInvocationURI.slice(expectedRunPrefix.length)) &&
-      certificate.runnerEnvironment === 'github-hosted' &&
-      certificate.sourceRepositoryDigest === identity.sourceSha
-  })
-  if (!hasSelectedIdentity) {
-    throw new Error('Artifact attestation does not match the selected CI run and source identity.')
-  }
 }
 
 export function releaseAssetRepairPlan(

--- a/scripts/package-release-promote.ts
+++ b/scripts/package-release-promote.ts
@@ -5,13 +5,10 @@ import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-import type { PackageReleaseAttestationIdentity } from './package-release-artifact-contract'
 import type { PackageReleasePublicationEnvironment } from './package-release-promotion'
 
 const CLI_ARGUMENT_START_INDEX = 2
 const EXPECTED_CLI_ARGUMENT_COUNT = 2
-const GH_ATTESTATION_COMMAND_PREFIX_LENGTH = 2
-
 interface PackageReleasePlan {
   readonly sourceSha: string
 }
@@ -28,6 +25,7 @@ interface PackageReleaseArtifact {
 interface PackageReleaseArtifactManifest {
   readonly packages: readonly PackageReleaseArtifact[]
   readonly sourceSha: string
+  readonly sourceTree: string
 }
 
 interface PromotionDependencies {
@@ -57,20 +55,22 @@ interface PromotionModule {
 }
 
 interface ArtifactContractModule {
-  readonly assertPackageReleaseAttestationIdentity: (
-    value: unknown,
-    identity: PackageReleaseAttestationIdentity,
-  ) => void
-  readonly packageReleaseAttestationVerificationArgs: (
-    file: string,
-    repository: string,
-    sourceSha: string,
-  ) => readonly string[]
   readonly releaseAssetRepairPlan: (
     value: unknown,
     tag: string,
     expectedNames: readonly string[],
   ) => Readonly<{ missingNames: readonly string[]; presentNames: readonly string[] }>
+}
+
+interface ProvenanceModule {
+  readonly verifyPackageReleaseArtifactProvenance: (input: Readonly<{
+    artifactFiles: readonly string[]
+    artifactRoot: string
+    candidateSourceSha: string
+    repository: string
+    runId: string
+    sourceTree: string
+  }>) => Promise<void>
 }
 
 interface CommandResult {
@@ -113,8 +113,6 @@ async function loadPromotionModule() {
 
 function isArtifactContractModule(value: unknown): value is ArtifactContractModule {
   return isJsonObject(value) &&
-    typeof value.assertPackageReleaseAttestationIdentity === 'function' &&
-    typeof value.packageReleaseAttestationVerificationArgs === 'function' &&
     typeof value.releaseAssetRepairPlan === 'function'
 }
 
@@ -123,6 +121,20 @@ async function loadArtifactContractModule() {
   const loaded: unknown = await import(moduleUrl)
   if (!isArtifactContractModule(loaded)) {
     throw new Error('Package release artifact contract module is invalid.')
+  }
+  return loaded
+}
+
+function isProvenanceModule(value: unknown): value is ProvenanceModule {
+  return isJsonObject(value) &&
+    typeof value.verifyPackageReleaseArtifactProvenance === 'function'
+}
+
+async function loadProvenanceModule() {
+  const moduleUrl = new URL('./package-release-provenance.ts', import.meta.url).href
+  const loaded: unknown = await import(moduleUrl)
+  if (!isProvenanceModule(loaded)) {
+    throw new Error('Package release provenance module is invalid.')
   }
   return loaded
 }
@@ -236,29 +248,6 @@ function sleep(durationMs: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, durationMs))
 }
 
-async function verifyArtifactProvenance(
-  artifactRoot: string,
-  manifest: PackageReleaseArtifactManifest,
-  identity: PackageReleaseAttestationIdentity,
-) {
-  const artifactContract = await loadArtifactContractModule()
-  for (const file of [
-    path.join(artifactRoot, 'release-artifacts.json'),
-    ...manifest.packages.map(({ file }) => path.join(artifactRoot, file)),
-  ]) {
-    const verificationArgs = artifactContract.packageReleaseAttestationVerificationArgs(
-      file,
-      identity.repository,
-      identity.sourceSha,
-    )
-    const verification = await run(
-      'gh', ['attestation', 'verify', ...verificationArgs.slice(GH_ATTESTATION_COMMAND_PREFIX_LENGTH)],
-    )
-    const result: unknown = JSON.parse(verification.stdout)
-    artifactContract.assertPackageReleaseAttestationIdentity(result, identity)
-  }
-}
-
 export async function runPackageReleasePromoteCli(args: readonly string[]) {
   if (args.length !== EXPECTED_CLI_ARGUMENT_COUNT) {
     throw new Error('Usage: package-release-promote.ts <plan-json> <artifact-root>.')
@@ -288,10 +277,17 @@ export async function runPackageReleasePromoteCli(args: readonly string[]) {
   if (manifest.sourceSha !== selectedSourceSha) {
     throw new Error('Package artifact source SHA does not match its successful CI run.')
   }
-  await verifyArtifactProvenance(artifactRoot, manifest, {
+  const provenance = await loadProvenanceModule()
+  await provenance.verifyPackageReleaseArtifactProvenance({
+    artifactFiles: [
+      'release-artifacts.json',
+      ...manifest.packages.map(({ file }) => file),
+    ],
+    artifactRoot,
+    candidateSourceSha: selectedSourceSha,
     repository,
     runId: selectedRunId,
-    sourceSha: selectedSourceSha,
+    sourceTree: manifest.sourceTree,
   })
   await promotion.promoteVerifiedPackageRelease(plan, manifest, artifactRoot, {
     ensureGitHubRelease,

--- a/scripts/package-release-provenance.ts
+++ b/scripts/package-release-provenance.ts
@@ -1,0 +1,161 @@
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+
+export interface PackageReleaseAttestationIdentity {
+  readonly repository: string
+  readonly runId: string
+}
+
+interface PackageReleaseProvenanceInput extends PackageReleaseAttestationIdentity {
+  readonly artifactFiles: readonly string[]
+  readonly artifactRoot: string
+  readonly candidateSourceSha: string
+  readonly sourceTree: string
+}
+
+function isJsonObject(value: unknown): value is { readonly [key: string]: unknown } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function packageReleaseAttestationVerificationArgs(
+  file: string,
+  repository: string,
+) {
+  return [
+    'attestation',
+    'verify',
+    file,
+    '--repo',
+    repository,
+    '--signer-workflow',
+    `${repository}/.github/workflows/ci.yml`,
+    '--deny-self-hosted-runners',
+    '--format',
+    'json',
+  ]
+}
+
+function attestationSourceSha(
+  entry: unknown,
+  expectedWorkflowPrefix: string,
+  expectedRunPrefix: string,
+) {
+  if (
+    !isJsonObject(entry) ||
+    !isJsonObject(entry.verificationResult) ||
+    !isJsonObject(entry.verificationResult.signature) ||
+    !isJsonObject(entry.verificationResult.signature.certificate)
+  ) {
+    return undefined
+  }
+  const certificate = entry.verificationResult.signature.certificate
+  if (
+    typeof certificate.buildConfigURI !== 'string' ||
+    !certificate.buildConfigURI.startsWith(expectedWorkflowPrefix) ||
+    typeof certificate.runInvocationURI !== 'string' ||
+    !certificate.runInvocationURI.startsWith(expectedRunPrefix) ||
+    !/^\d+$/.test(certificate.runInvocationURI.slice(expectedRunPrefix.length)) ||
+    certificate.runnerEnvironment !== 'github-hosted' ||
+    typeof certificate.sourceRepositoryDigest !== 'string'
+  ) {
+    return undefined
+  }
+  return certificate.sourceRepositoryDigest
+}
+
+export function assertPackageReleaseAttestationIdentity(
+  value: unknown,
+  identity: PackageReleaseAttestationIdentity,
+) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('Artifact attestation verification returned no identity result.')
+  }
+  const expectedWorkflowPrefix =
+    `https://github.com/${identity.repository}/.github/workflows/ci.yml@`
+  const expectedRunPrefix =
+    `https://github.com/${identity.repository}/actions/runs/${identity.runId}/attempts/`
+  const sourceShas = new Set(
+    value
+      .map((entry) => attestationSourceSha(entry, expectedWorkflowPrefix, expectedRunPrefix))
+      .filter((sourceSha) => sourceSha !== undefined),
+  )
+  if (sourceShas.size !== 1) {
+    throw new Error('Artifact attestation does not match the selected CI run and source identity.')
+  }
+  const sourceSha = sourceShas.values().next().value
+  if (sourceSha === undefined) {
+    throw new Error('Artifact attestation source identity is unavailable.')
+  }
+  return sourceSha
+}
+
+export function assertPackageReleaseAttestationSourceCommit(
+  value: unknown,
+  identity: Readonly<{
+    attestationSourceSha: string
+    candidateSourceSha: string
+    sourceTree: string
+  }>,
+) {
+  if (
+    !isJsonObject(value) ||
+    value.sha !== identity.attestationSourceSha ||
+    !isJsonObject(value.tree) ||
+    value.tree.sha !== identity.sourceTree ||
+    !Array.isArray(value.parents) ||
+    !value.parents.every((parent) => isJsonObject(parent) && typeof parent.sha === 'string') ||
+    (identity.attestationSourceSha !== identity.candidateSourceSha &&
+      !value.parents.some(
+        (parent) => isJsonObject(parent) && parent.sha === identity.candidateSourceSha,
+      ))
+  ) {
+    throw new Error('Attested source commit does not match the candidate head and source tree.')
+  }
+}
+
+function runGh(args: readonly string[]) {
+  return new Promise<unknown>((resolve, reject) => {
+    execFile('gh', args, { encoding: 'utf8' }, (error, stdout, stderr) => {
+      if (error !== null) {
+        reject(new Error(stderr.trim() || error.message))
+        return
+      }
+      try {
+        resolve(JSON.parse(stdout))
+      } catch (parseError) {
+        reject(parseError)
+      }
+    })
+  })
+}
+
+export async function verifyPackageReleaseArtifactProvenance(
+  input: PackageReleaseProvenanceInput,
+) {
+  const sourceShas = new Set<string>()
+  for (const artifactFile of input.artifactFiles) {
+    const verification = await runGh(
+      packageReleaseAttestationVerificationArgs(
+        path.join(input.artifactRoot, artifactFile),
+        input.repository,
+      ),
+    )
+    sourceShas.add(assertPackageReleaseAttestationIdentity(verification, input))
+  }
+  if (sourceShas.size !== 1) {
+    throw new Error('Package artifacts do not share one attested source commit.')
+  }
+  const attestationSourceSha = sourceShas.values().next().value
+  if (attestationSourceSha === undefined) {
+    throw new Error('Package artifact attestation source is unavailable.')
+  }
+  const sourceCommit = await runGh([
+    'api',
+    `repos/${input.repository}/git/commits/${attestationSourceSha}`,
+  ])
+  assertPackageReleaseAttestationSourceCommit(sourceCommit, {
+    attestationSourceSha,
+    candidateSourceSha: input.candidateSourceSha,
+    sourceTree: input.sourceTree,
+  })
+}

--- a/scripts/package-release-validator-pipeline.ts
+++ b/scripts/package-release-validator-pipeline.ts
@@ -260,7 +260,7 @@ function validatePackageReleaseWorkflow(
     ['ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'package-release-promote.ts must verify the GitHub OIDC environment.'],
     ["environment.eventName === 'workflow_dispatch'", 'package-release-promote.ts must recognize only explicit recovery dispatches.'],
     ['environment.recoveryReleaseSha', 'package-release-promote.ts must bind recovery to the planned source SHA.'],
-    ["'gh', ['attestation', 'verify'", 'package-release-promote.ts must verify artifact provenance.'],
+    ['verifyPackageReleaseArtifactProvenance', 'package-release-promote.ts must verify artifact provenance.'],
     ['has different integrity on npm', 'package-release-promote.ts must fail closed on registry byte substitution.'],
     ['isTransientPublicationFailure', 'package-release-promote.ts must retry only transient publication failures.'],
     ['await dependencies.ensureTag', 'package-release-promote.ts must create immutable tags after npm acceptance.'],

--- a/scripts/package-release-validator-provenance.ts
+++ b/scripts/package-release-validator-provenance.ts
@@ -1,0 +1,35 @@
+function addViolation(condition: boolean, message: string, violations: string[]) {
+  if (condition) violations.push(message)
+}
+
+function requireText(
+  source: string,
+  requirements: readonly (readonly [string, string])[],
+  violations: string[],
+) {
+  for (const [snippet, message] of requirements) {
+    addViolation(!source.includes(snippet), message, violations)
+  }
+}
+
+export function validatePackageReleaseProvenance(
+  provenanceSource: string,
+  violations: string[],
+) {
+  requireText(provenanceSource, [
+    ['packageReleaseAttestationVerificationArgs', 'package-release-provenance.ts must define the GitHub attestation verification contract.'],
+    ['--signer-workflow', 'package-release-provenance.ts must bind attestations to the trusted CI workflow.'],
+    ['--deny-self-hosted-runners', 'package-release-provenance.ts must reject self-hosted attestation runners.'],
+    ['runInvocationURI', 'package-release-provenance.ts must bind attestations to the selected CI run.'],
+    ["runnerEnvironment !== 'github-hosted'", 'package-release-provenance.ts must require GitHub-hosted attestation identity.'],
+    ['assertPackageReleaseAttestationSourceCommit', 'package-release-provenance.ts must validate the attested source commit.'],
+    ['candidateSourceSha', 'package-release-provenance.ts must bind pull-request attestations to the candidate head.'],
+    ['sourceTree', 'package-release-provenance.ts must bind attestations to the release source tree.'],
+    ['git/commits/${attestationSourceSha}', 'package-release-provenance.ts must resolve the exact attested Git commit.'],
+  ], violations)
+  addViolation(
+    provenanceSource.includes("'--source-digest'"),
+    'package-release-provenance.ts must not assume a pull-request attestation uses the candidate head digest.',
+    violations,
+  )
+}

--- a/scripts/package-release-validator-provenance.ts
+++ b/scripts/package-release-validator-provenance.ts
@@ -28,7 +28,7 @@ export function validatePackageReleaseProvenance(
     ['git/commits/${attestationSourceSha}', 'package-release-provenance.ts must resolve the exact attested Git commit.'],
   ], violations)
   addViolation(
-    provenanceSource.includes("'--source-digest'"),
+    provenanceSource.includes('--source-digest'),
     'package-release-provenance.ts must not assume a pull-request attestation uses the candidate head digest.',
     violations,
   )

--- a/scripts/package-release-validator.ts
+++ b/scripts/package-release-validator.ts
@@ -2,6 +2,7 @@ import { access, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { validatePackageReleasePipelines } from './package-release-validator-pipeline'
+import { validatePackageReleaseProvenance } from './package-release-validator-provenance'
 import { RELEASE_PLEASE_CONTRACT } from './release-please-contract'
 import { validateReleasePleaseRuntimeContract } from './release-please-runtime-contract'
 
@@ -237,6 +238,7 @@ export async function validatePackageReleaseFiles(
     artifactsSource,
     contractSource,
     locatorSource,
+    provenanceSource,
   ] = await Promise.all([
     readFile(path.join(projectRoot, WORKFLOW_PATH), 'utf8'),
     readFile(path.join(projectRoot, CI_WORKFLOW_PATH), 'utf8'),
@@ -246,6 +248,7 @@ export async function validatePackageReleaseFiles(
     readFile(path.join(projectRoot, 'scripts/package-release-artifacts.ts'), 'utf8'),
     readFile(path.join(projectRoot, 'scripts/package-release-artifact-contract.ts'), 'utf8'),
     readFile(path.join(projectRoot, 'scripts/package-release-artifact-locator.ts'), 'utf8'),
+    readFile(path.join(projectRoot, 'scripts/package-release-provenance.ts'), 'utf8'),
   ])
   validatePackageReleasePipelines({
     artifactsSource: `${artifactsSource}\n${contractSource}`,
@@ -255,6 +258,7 @@ export async function validatePackageReleaseFiles(
     promoteSource: `${promoteSource}\n${promotionSource}`,
     workflowText,
   }, violations)
+  validatePackageReleaseProvenance(provenanceSource, violations)
   return { violations }
 }
 


### PR DESCRIPTION
## Summary
- verify package provenance against GitHub's attested pull-request merge commit rather than assuming the candidate head is the attested digest
- require the attested commit to contain the candidate head as a parent and to have the exact release tree
- add a fail-before-merge validator that rejects the broken `--source-digest` assumption

## Validation
- `pnpm check`
- `pnpm test`
- exact artifact rehearsal against CI run `29906177258` and tree `2c63154a4aaa05bb7effe93a5cb86d0dca7952fa`
- local code review: no valid findings

## Release impact
Internal package publication infrastructure only; this does not change package contents or versions.